### PR TITLE
SwiftCOM: make interfaces more open

### DIFF
--- a/Sources/SwiftCOM/Interfaces/ITypeComp.swift
+++ b/Sources/SwiftCOM/Interfaces/ITypeComp.swift
@@ -10,7 +10,7 @@ import WinSDK
 /// Provides a fast way to access information that compilers need when binding to
 /// and instantiating structures and interfaces. Binding is the process of
 /// mapping names to types and type members.
-public class ITypeComp: IUnknown {
+open class ITypeComp: IUnknown {
   public override class var IID: IID { IID_ITypeComp }
 
   /// Maps a name to a member of a type, or binds global variables and functions

--- a/Sources/SwiftCOM/Interfaces/ITypeInfo.swift
+++ b/Sources/SwiftCOM/Interfaces/ITypeInfo.swift
@@ -7,7 +7,7 @@
 
 import WinSDK
 
-public class ITypeInfo: IUnknown {
+open class ITypeInfo: IUnknown {
   public override class var IID: IID { IID_ITypeInfo }
 
   // TODO(compnerd) create a managed copy of TYPEATTR

--- a/Sources/SwiftCOM/Interfaces/ITypeLib.swift
+++ b/Sources/SwiftCOM/Interfaces/ITypeLib.swift
@@ -7,7 +7,7 @@
 
 import WinSDK
 
-public class ITypeLib: IUnknown {
+open class ITypeLib: IUnknown {
   public override class var IID: IID { IID_ITypeLib }
 
   /// Provides the number of type descriptions that are in a type library.

--- a/Sources/SwiftCOM/Interfaces/IUnknown.swift
+++ b/Sources/SwiftCOM/Interfaces/IUnknown.swift
@@ -10,11 +10,11 @@ import WinSDK
 /// Enables clients to get pointers to other interfaces on a given object through
 /// the `QueryInterface` method, and manage the existence of the object through
 /// the `AddRef` and `Release` methods.
-public class IUnknown {
+open class IUnknown {
   public var pUnk: UnsafeMutablePointer<WinSDK.IUnknown>?
 
   /// Interface ID
-  public class var IID: IID { IID_IUnknown }
+  open class var IID: IID { IID_IUnknown }
 
   /// Converts the unmanaged `IUnknown` pointer to a managed instance.  The pointee
   /// is expected to be passed in with a reference count of 1.


### PR DESCRIPTION
Allow the classes to be re-opened outside of the module as COM
extensions are a primary motivation for this package.