### PR TITLE
Interfaces: add a few more core types

### DIFF
--- a/Sources/SwiftCOM/Interfaces/Human/IEnumUnknown.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IEnumUnknown.swift
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All Rights Reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+import WinSDK
+
+public class IEnumUnknown: IUnknown {
+  override public class var IID: IID { IID_IEnumUnknown }
+
+  public func Clone() throws -> IEnumUnknown {
+    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
+      throw COMError(hr: E_INVALIDARG)
+    }
+    let pThis = pUnk.bindMemory(to: WinSDK.IEnumUnknown.self, capacity: 1)
+
+    var penum: UnsafeMutablePointer<WinSDK.IEnumUnknown>?
+    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Clone(pThis, &penum)
+    guard hr == S_OK else { throw COMError(hr: hr) }
+    return IEnumUnknown(pUnk: penum)
+  }
+
+  public func Next(_ celt: ULONG) throws -> [IUnknown] {
+    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
+      throw COMError(hr: E_INVALIDARG)
+    }
+    let pThis = pUnk.bindMemory(to: WinSDK.IEnumUnknown.self, capacity: 1)
+
+    var rgelt: UnsafeMutablePointer<WinSDK.IUnknown>?
+    var celtFetched: ULONG = 0
+    let hr: HRESULT =
+        pThis.pointee.lpVtbl.pointee.Next(pThis, celt, &rgelt, &celtFetched)
+    guard hr == S_OK else { throw COMError(hr: hr) }
+
+    var result: [IUnknown] = []
+    result.reserveCapacity(Int(celtFetched))
+    _ = rgelt?.withMemoryRebound(to: Optional<UnsafeMutablePointer<WinSDK.IUnknown>>.self,
+                                 capacity: Int(celtFetched)) { rgelt in
+      for i in 0 ..< Int(celtFetched) {
+        result.append(IUnknown(pUnk: rgelt[i]))
+      }
+    }
+    return result
+  }
+
+  public func Reset() throws {
+    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
+      throw COMError(hr: E_INVALIDARG)
+    }
+    let pThis = pUnk.bindMemory(to: WinSDK.IEnumUnknown.self, capacity: 1)
+
+    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Reset(pThis)
+    guard hr == S_OK else { throw COMError(hr: hr) }
+  }
+
+  public func Skip(_ celt: ULONG) throws {
+    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
+      throw COMError(hr: E_INVALIDARG)
+    }
+    let pThis = pUnk.bindMemory(to: WinSDK.IEnumUnknown.self, capacity: 1)
+
+    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Skip(pThis, celt)
+    guard hr == S_OK else { throw COMError(hr: hr) }
+  }
+}

--- a/Sources/SwiftCOM/Interfaces/Human/IErrorLog.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IErrorLog.swift
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All Rights Reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+import WinSDK
+
+public class IErrorLog: IUnknown {
+  override public class var IID: IID { IID_IErrorLog }
+
+  public func AddError(_ szPropName: String, _ pExcepInfo: [EXCEPINFO]) throws {
+    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
+      throw COMError(hr: E_INVALIDARG)
+    }
+    let pThis = pUnk.bindMemory(to: WinSDK.IErrorLog.self, capacity: 1)
+
+    var pExcepInfo = pExcepInfo
+    let hr: HRESULT = szPropName.withCString(encodedAs: UTF16.self) { pwszPropName in
+      pExcepInfo.withUnsafeMutableBufferPointer {
+        pThis.pointee.lpVtbl.pointee.AddError(pThis, pwszPropName, $0.baseAddress)
+      }
+    }
+    guard hr == S_OK else { throw COMError(hr: hr) }
+  }
+}

--- a/Sources/SwiftCOM/Interfaces/Human/IPropertyBag2.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IPropertyBag2.swift
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All Rights Reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+import WinSDK
+
+public class IPropertyBag2: IUnknown {
+  override public class var IID: IID { IID_IPropertyBag2 }
+
+  public func CountProperties() throws -> ULONG {
+    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
+      throw COMError(hr: E_INVALIDARG)
+    }
+    let pThis = pUnk.bindMemory(to: WinSDK.IPropertyBag2.self, capacity: 1)
+
+    var cProperties: ULONG = ULONG(0)
+    let hr: HRESULT =
+        pThis.pointee.lpVtbl.pointee.CountProperties(pThis, &cProperties)
+    guard hr == S_OK else { throw COMError(hr: hr) }
+    return cProperties
+  }
+
+  public func GetPropertyInfo(_ iProperty: ULONG, _ cProperties: ULONG)
+      throws -> [PROPBAG2] {
+    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
+      throw COMError(hr: E_INVALIDARG)
+    }
+    let pThis = pUnk.bindMemory(to: WinSDK.IPropertyBag2.self, capacity: 1)
+
+    return try Array<PROPBAG2>(unsafeUninitializedCapacity: Int(cProperties)) {
+      var count: ULONG = ULONG(0)
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetPropertyInfo(pThis, iProperty,
+                                                       cProperties,
+                                                       $0.baseAddress, &count)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      $1 = Int(count)
+    }
+  }
+
+  public func LoadObject(_ strName: String, _ dwHint: DWORD,
+                         _ pUnkObject: IUnknown, _ pErrLog: IErrorLog) throws {
+    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
+      throw COMError(hr: E_INVALIDARG)
+    }
+    let pThis = pUnk.bindMemory(to: WinSDK.IPropertyBag2.self, capacity: 1)
+
+    let hr: HRESULT = strName.withCString(encodedAs: UTF16.self) {
+      pThis.pointee.lpVtbl.pointee.LoadObject(pThis, $0, dwHint,
+                                              RawPointer(pUnkObject),
+                                              RawPointer(pErrLog))
+    }
+    guard hr == S_OK else { throw COMError(hr: hr) }
+  }
+
+  public func Read(_ pPropBag: [PROPBAG2], _ pErrLog: IErrorLog?)
+      throws -> [(VARIANT, HRESULT)] {
+    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
+      throw COMError(hr: E_INVALIDARG)
+    }
+    let pThis = pUnk.bindMemory(to: WinSDK.IPropertyBag2.self, capacity: 1)
+
+    var pPropBag = pPropBag
+    var hrError: [HRESULT] =
+        Array<HRESULT>(repeating: S_OK, count: pPropBag.count)
+    let varValue: [VARIANT] =
+        try Array<VARIANT>(unsafeUninitializedCapacity: pPropBag.count) { pvarValue, count in
+      let hr: HRESULT = pPropBag.withUnsafeMutableBufferPointer {
+        pThis.pointee.lpVtbl.pointee.Read(pThis, ULONG($0.count), $0.baseAddress,
+                                          RawPointer(pErrLog), pvarValue.baseAddress,
+                                          &hrError)
+      }
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      count = pPropBag.count
+    }
+    return zip(varValue, hrError).map { ($0.0, $0.1) }
+  }
+
+  public func Write(_ properties: [PROPBAG2], _ values: [VARIANT]) throws {
+    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
+      throw COMError(hr: E_INVALIDARG)
+    }
+    let pThis = pUnk.bindMemory(to: WinSDK.IPropertyBag2.self, capacity: 1)
+
+    guard properties.count == values.count else {
+      throw COMError(hr: E_INVALIDARG)
+    }
+
+    var properties = properties
+    var values = values
+    let hr: HRESULT = properties.withUnsafeMutableBufferPointer { pPropBag in
+      values.withUnsafeMutableBufferPointer { pvarValue in
+        pThis.pointee.lpVtbl.pointee.Write(pThis, ULONG(pPropBag.count),
+                                           pPropBag.baseAddress,
+                                           pvarValue.baseAddress)
+      }
+    }
+    guard hr == S_OK else { throw COMError(hr: hr) }
+  }
+}


### PR DESCRIPTION
`IEnumUnknown` is similar to `IEnumString` but returns `IUnknown`s.  The
`IErrorLog` is for error streams.  Although `IPropertyBag2` is part of
IE, it is used outside of IE as well.

These are supporting interfaces required for WIC.