### PR TITLE
COMBase: add an overload for `CoInitializeEx`

### DIFF
--- a/Sources/SwiftCOM/COMBase.swift
+++ b/Sources/SwiftCOM/COMBase.swift
@@ -7,6 +7,19 @@
 
 import WinSDK
 
+public func CoInitializeEx(_ pvReserved: LPVOID?,
+                           _ dwCoInit: COINIT) -> HRESULT {
+  return WinSDK.CoInitializeEx(pvReserved, DWORD(dwCoInit.rawValue))
+}
+
+public func CoInitializeEx(_ dwCoInit: COINIT = COINIT_MULTITHREADED) throws {
+  let hr: HRESULT = CoInitializeEx(nil, dwCoInit)
+  switch hr {
+  case S_OK, S_FALSE, RPC_E_CHANGED_MODE: break
+  default: throw COMError(hr: hr)
+  }
+}
+
 public func CoGetMalloc(_ dwMemContext: DWORD = 1) throws -> IMalloc {
   var pMalloc: LPMALLOC?
   let hr: HRESULT = CoGetMalloc(1, &pMalloc)

--- a/Sources/SwiftCOM/Extensions/WinSDK+Extensions.swift
+++ b/Sources/SwiftCOM/Extensions/WinSDK+Extensions.swift
@@ -27,6 +27,10 @@ internal var E_FAIL: HRESULT {
   HRESULT(bitPattern: 0x80004005)
 }
 
+internal var RPC_E_CHANGED_MODE: HRESULT {
+  HRESULT(bitPattern: 0x80010106)
+}
+
 // winnt.h
 @_transparent
 public func MAKELANGID(_ p: WORD, _ s: WORD) -> DWORD {


### PR DESCRIPTION
This adds an overload for the `CoInitializeEx` to avoid the explicit
casting at the use site.