### PR TITLE
build: prefer building a shared library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let SwiftCOM = Package(
   name: "SwiftCOM",
   products: [
-    .library(name: "SwiftCOM", targets: ["SwiftCOM"]),
+    .library(name: "SwiftCOM", type: .dynamic, targets: ["SwiftCOM"]),
   ],
   targets: [
     .target(name: "SwiftCOM", linkerSettings: [.linkedLibrary("Ole32")])


### PR DESCRIPTION
Generate a shared library for COM interfaces rather than a static
library.