### PR TITLE
SwiftCOM: mark `ISensorEvents` as `open`

### DIFF
--- a/Sources/SwiftCOM/Interfaces/Human/ISensorEvents.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ISensorEvents.swift
@@ -68,7 +68,7 @@ private var vtable: WinSDK.ISensorEventsVtbl = .init(
   }
 )
 
-public class ISensorEvents: IUnknown {
+open class ISensorEvents: IUnknown {
   override public class var IID: IID { IID_ISensorManagerEvents }
 
   fileprivate struct Object {


### PR DESCRIPTION
This class should be marked as `open` as it is intended to be
an interface implemented by users.