### PR TITLE
ISensorManager: add overload for GUID

### DIFF
--- a/Sources/SwiftCOM/Interfaces/Human/ISensorManager.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ISensorManager.swift
@@ -79,3 +79,11 @@ public class ISensorManager: IUnknown {
     guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }
+
+extension ISensorManager {
+  public func GetSensorsByType(_ sensorType: SENSOR_TYPE_ID)
+      throws -> ISensorCollection {
+    var sensorType = sensorType
+    return try GetSensorsByType(&sensorType)
+  }
+}


### PR DESCRIPTION
This adds an extension that takes a GUID by value rather than reference
and converts the value to a reference internally.