### PR TITLE
SwiftCOM: implement `IUnknown.perform(as:_:)`

### DIFF
--- a/Sources/SwiftCOM/Interfaces/Human/IBindCtx.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IBindCtx.swift
@@ -11,123 +11,94 @@ public class IBindCtx: IUnknown {
   override public class var IID: IID { IID_IBindCtx }
 
   public func EnumObjectParam() throws -> IEnumString {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IBindCtx.self) { pThis in
+      var penum: UnsafeMutablePointer<WinSDK.IEnumString>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.EnumObjectParam(pThis, &penum)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IEnumString(pUnk: penum)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IBindCtx.self, capacity: 1)
-
-    var penum: UnsafeMutablePointer<WinSDK.IEnumString>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.EnumObjectParam(pThis, &penum)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IEnumString(pUnk: penum)
   }
 
   public func GetBindOptions() throws -> BIND_OPTS {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IBindCtx.self) { pThis in
+      var bindopts: BIND_OPTS = BIND_OPTS()
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetBindOptions(pThis, &bindopts)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return bindopts
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IBindCtx.self, capacity: 1)
-
-    var bindopts: BIND_OPTS = BIND_OPTS()
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetBindOptions(pThis, &bindopts)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return bindopts
   }
 
   public func GetObjectParam(_ pszKey: String) throws -> IUnknown {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IBindCtx.self) { pThis in
+      var pUnk: UnsafeMutablePointer<WinSDK.IUnknown>?
+      var key: [OLECHAR] = pszKey.wide
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetObjectParam(pThis, &key, &pUnk)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IUnknown(pUnk: pUnk)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IBindCtx.self, capacity: 1)
-
-    var punk: UnsafeMutablePointer<WinSDK.IUnknown>?
-    var key: [OLECHAR] = pszKey.wide
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetObjectParam(pThis, &key, &punk)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IUnknown(pUnk: punk)
   }
 
   public func GetRunningObjectTable() throws -> IRunningObjectTable {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IBindCtx.self) { pThis in
+      var prot: UnsafeMutablePointer<WinSDK.IRunningObjectTable>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetRunningObjectTable(pThis, &prot)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IRunningObjectTable(pUnk: prot)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IBindCtx.self, capacity: 1)
-
-    var prot: UnsafeMutablePointer<WinSDK.IRunningObjectTable>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetRunningObjectTable(pThis, &prot)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IRunningObjectTable(pUnk: prot)
   }
 
-  public func RegisterObjectBound(_ punk: IUnknown) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+  public func RegisterObjectBound(_ pUnk: IUnknown) throws {
+    return try perform(as: WinSDK.IBindCtx.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.RegisterObjectBound(pThis, pUnk.pUnk)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IBindCtx.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.RegisterObjectBound(pThis, punk.pUnk)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
-  public func RegisterObjectParam(_ pszKey: String, _ punk: IUnknown)
+  public func RegisterObjectParam(_ pszKey: String, _ pUnk: IUnknown)
       throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IBindCtx.self) { pThis in
+      var key: [OLECHAR] = pszKey.wide
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.RegisterObjectParam(pThis, &key,
+                                                           pUnk.pUnk)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IBindCtx.self, capacity: 1)
-
-    var key: [OLECHAR] = pszKey.wide
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.RegisterObjectParam(pThis, &key, punk.pUnk)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func ReleaseBoundObjects() throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IBindCtx.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.ReleaseBoundObjects(pThis)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IBindCtx.self, capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.ReleaseBoundObjects(pThis)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func RevokeObjectBound(_ punk: IUnknown) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IBindCtx.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.RevokeObjectBound(pThis, punk.pUnk)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IBindCtx.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.RevokeObjectBound(pThis, punk.pUnk)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func RevokeObjectParam(_ pszKey: String) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IBindCtx.self) { pThis in
+      var key: [OLECHAR] = pszKey.wide
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.RevokeObjectParam(pThis, &key)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IBindCtx.self, capacity: 1)
-
-    var key: [OLECHAR] = pszKey.wide
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.RevokeObjectParam(pThis, &key)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetBindOptions(_ pbindopts: inout BIND_OPTS) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IBindCtx.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.SetBindOptions(pThis, &pbindopts)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IBindCtx.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetBindOptions(pThis, &pbindopts)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IEnumMoniker.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IEnumMoniker.swift
@@ -11,59 +11,47 @@ public class IEnumMoniker: IUnknown {
   override public class var IID: IID { IID_IEnumMoniker }
 
   public func Clone() throws -> IEnumMoniker {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IEnumMoniker.self) { pThis in
+      var penum: UnsafeMutablePointer<WinSDK.IEnumMoniker>?
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Clone(pThis, &penum)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IEnumMoniker(pUnk: penum)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IEnumMoniker.self, capacity: 1)
-
-    var penum: UnsafeMutablePointer<WinSDK.IEnumMoniker>?
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Clone(pThis, &penum)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IEnumMoniker(pUnk: penum)
   }
 
   public func Next(_ celt: ULONG) throws -> [IMoniker] {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis = pUnk.bindMemory(to: WinSDK.IEnumMoniker.self, capacity: 1)
+    return try perform(as: WinSDK.IEnumMoniker.self) { pThis in
+      var rgelt: UnsafeMutablePointer<WinSDK.IMoniker>?
+      var celtFetched: ULONG = 0
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.Next(pThis, celt, &rgelt, &celtFetched)
+      guard hr == S_OK else { throw COMError(hr: hr) }
 
-    var rgelt: UnsafeMutablePointer<WinSDK.IMoniker>?
-    var celtFetched: ULONG = 0
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.Next(pThis, celt, &rgelt, &celtFetched)
-    guard hr == S_OK else { throw COMError(hr: hr) }
+      defer { CoTaskMemFree(rgelt) }
 
-    defer { CoTaskMemFree(rgelt) }
-
-    var monikers: [IMoniker] = []
-    monikers.reserveCapacity(Int(celtFetched))
-    _ = rgelt?.withMemoryRebound(to: UnsafeMutablePointer<WinSDK.IMoniker?>.self,
-                                 capacity: Int(celtFetched)) { rgelt in
-      for i in 0 ..< Int(celtFetched) {
-        monikers.append(IMoniker(pUnk: rgelt[i]))
+      var monikers: [IMoniker] = []
+      monikers.reserveCapacity(Int(celtFetched))
+      _ = rgelt?.withMemoryRebound(to: UnsafeMutablePointer<WinSDK.IMoniker?>.self,
+                                  capacity: Int(celtFetched)) { rgelt in
+        for i in 0 ..< Int(celtFetched) {
+          monikers.append(IMoniker(pUnk: rgelt[i]))
+        }
       }
+      return monikers
     }
-    return monikers
   }
 
   public func Reset() throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IEnumMoniker.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Reset(pThis)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IEnumMoniker.self, capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Reset(pThis)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func Skip(_ celt: ULONG) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IEnumMoniker.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Skip(pThis, celt)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IEnumMoniker.self, capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Skip(pThis, celt)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IEnumString.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IEnumString.swift
@@ -11,59 +11,47 @@ public class IEnumString: IUnknown {
   override public class var IID: IID { IID_IEnumString }
 
   public func Clone() throws -> IEnumString {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IEnumString.self) { pThis in
+      var penum: UnsafeMutablePointer<WinSDK.IEnumString>?
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Clone(pThis, &penum)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IEnumString(pUnk: penum)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IEnumString.self, capacity: 1)
-
-    var penum: UnsafeMutablePointer<WinSDK.IEnumString>?
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Clone(pThis, &penum)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IEnumString(pUnk: penum)
   }
 
   public func Next(_ celt: ULONG) throws -> [String] {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis = pUnk.bindMemory(to: WinSDK.IEnumString.self, capacity: 1)
+    return try perform(as: WinSDK.IEnumString.self) { pThis in
+      var rgelt: LPOLESTR?
+      var celtFetched: ULONG = 0
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.Next(pThis, celt, &rgelt, &celtFetched)
+      guard hr == S_OK else { throw COMError(hr: hr) }
 
-    var rgelt: LPOLESTR?
-    var celtFetched: ULONG = 0
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.Next(pThis, celt, &rgelt, &celtFetched)
-    guard hr == S_OK else { throw COMError(hr: hr) }
+      defer { CoTaskMemFree(rgelt) }
 
-    defer { CoTaskMemFree(rgelt) }
-
-    var result: [String] = []
-    result.reserveCapacity(Int(celtFetched))
-    _ = rgelt?.withMemoryRebound(to: LPOLESTR?.self,
-                                 capacity: Int(celtFetched)) { rgelt in
-      for i in 0 ..< Int(celtFetched) {
-        result.append(String(decodingCString: rgelt[i]!, as: UTF16.self))
+      var result: [String] = []
+      result.reserveCapacity(Int(celtFetched))
+      _ = rgelt?.withMemoryRebound(to: LPOLESTR?.self,
+                                  capacity: Int(celtFetched)) { rgelt in
+        for i in 0 ..< Int(celtFetched) {
+          result.append(String(decodingCString: rgelt[i]!, as: UTF16.self))
+        }
       }
+      return result
     }
-    return result
   }
 
   public func Reset() throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IEnumString.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Reset(pThis)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IEnumString.self, capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Reset(pThis)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func Skip(_ celt: ULONG) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IEnumString.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Skip(pThis, celt)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IEnumString.self, capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Skip(pThis, celt)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IEnumUnknown.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IEnumUnknown.swift
@@ -11,57 +11,45 @@ public class IEnumUnknown: IUnknown {
   override public class var IID: IID { IID_IEnumUnknown }
 
   public func Clone() throws -> IEnumUnknown {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IEnumUnknown.self) { pThis in
+      var penum: UnsafeMutablePointer<WinSDK.IEnumUnknown>?
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Clone(pThis, &penum)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IEnumUnknown(pUnk: penum)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IEnumUnknown.self, capacity: 1)
-
-    var penum: UnsafeMutablePointer<WinSDK.IEnumUnknown>?
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Clone(pThis, &penum)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IEnumUnknown(pUnk: penum)
   }
 
   public func Next(_ celt: ULONG) throws -> [IUnknown] {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis = pUnk.bindMemory(to: WinSDK.IEnumUnknown.self, capacity: 1)
+    return try perform(as: WinSDK.IEnumUnknown.self) { pThis in
+      var rgelt: UnsafeMutablePointer<WinSDK.IUnknown>?
+      var celtFetched: ULONG = 0
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.Next(pThis, celt, &rgelt, &celtFetched)
+      guard hr == S_OK else { throw COMError(hr: hr) }
 
-    var rgelt: UnsafeMutablePointer<WinSDK.IUnknown>?
-    var celtFetched: ULONG = 0
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.Next(pThis, celt, &rgelt, &celtFetched)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-
-    var result: [IUnknown] = []
-    result.reserveCapacity(Int(celtFetched))
-    _ = rgelt?.withMemoryRebound(to: Optional<UnsafeMutablePointer<WinSDK.IUnknown>>.self,
-                                 capacity: Int(celtFetched)) { rgelt in
-      for i in 0 ..< Int(celtFetched) {
-        result.append(IUnknown(pUnk: rgelt[i]))
+      var result: [IUnknown] = []
+      result.reserveCapacity(Int(celtFetched))
+      _ = rgelt?.withMemoryRebound(to: Optional<UnsafeMutablePointer<WinSDK.IUnknown>>.self,
+                                  capacity: Int(celtFetched)) { rgelt in
+        for i in 0 ..< Int(celtFetched) {
+          result.append(IUnknown(pUnk: rgelt[i]))
+        }
       }
+      return result
     }
-    return result
   }
 
   public func Reset() throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IEnumUnknown.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Reset(pThis)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IEnumUnknown.self, capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Reset(pThis)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func Skip(_ celt: ULONG) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IEnumUnknown.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Skip(pThis, celt)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IEnumUnknown.self, capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Skip(pThis, celt)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IErrorLog.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IErrorLog.swift
@@ -11,17 +11,14 @@ public class IErrorLog: IUnknown {
   override public class var IID: IID { IID_IErrorLog }
 
   public func AddError(_ szPropName: String, _ pExcepInfo: [EXCEPINFO]) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis = pUnk.bindMemory(to: WinSDK.IErrorLog.self, capacity: 1)
-
-    var pExcepInfo = pExcepInfo
-    let hr: HRESULT = szPropName.withCString(encodedAs: UTF16.self) { pwszPropName in
-      pExcepInfo.withUnsafeMutableBufferPointer {
-        pThis.pointee.lpVtbl.pointee.AddError(pThis, pwszPropName, $0.baseAddress)
+    return try perform(as: WinSDK.IErrorLog.self) { pThis in
+      var pExcepInfo = pExcepInfo
+      let hr: HRESULT = szPropName.withCString(encodedAs: UTF16.self) { pwszPropName in
+        pExcepInfo.withUnsafeMutableBufferPointer {
+          pThis.pointee.lpVtbl.pointee.AddError(pThis, pwszPropName, $0.baseAddress)
+        }
       }
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IFileOperation.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IFileOperation.swift
@@ -11,256 +11,202 @@ public class IFileOperation: IUnknown {
   override public class var IID: IID { IID_IFileOperation }
 
   public func Advise(_ pfops: IFileOperationProgressSink) throws -> DWORD {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IFileOperation.self) { pThis in
+      var dwCookie: DWORD = 0
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.Advise(pThis, RawPointer(pfops),
+                                              &dwCookie)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return dwCookie
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IFileOperation.self, capacity: 1)
-
-    var dwCookie: DWORD = 0
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.Advise(pThis, RawPointer(pfops), &dwCookie)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return dwCookie
   }
 
   public func ApplyPropertiesToItem(_ psiItem: IShellItem) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IFileOperation.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.ApplyPropertiesToItem(pThis,
+                                                            RawPointer(psiItem))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IFileOperation.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.ApplyPropertiesToItem(pThis,
-                                                           RawPointer(psiItem))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func ApplyPropertiesToItems(_ punkItems: IUnknown) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IFileOperation.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.ApplyPropertiesToItems(pThis,
+                                                              punkItems.pUnk)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IFileOperation.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.ApplyPropertiesToItems(pThis,
-                                                            punkItems.pUnk)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func CopyItem(_ psiItem: IShellItem,
                        _ psiDestinationFolder: IShellItem,
                        _ pszCopyName: String?,
                        _ pfopsItem: IFileOperationProgressSink?) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IFileOperation.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.CopyItem(pThis, RawPointer(psiItem),
+                                                RawPointer(psiDestinationFolder),
+                                                pszCopyName?.wide,
+                                                RawPointer(pfopsItem))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IFileOperation.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.CopyItem(pThis, RawPointer(psiItem),
-                                              RawPointer(psiDestinationFolder),
-                                              pszCopyName?.wide,
-                                              RawPointer(pfopsItem))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func CopyItems(_ punkItems: IUnknown,
                         _ psiDestinationFolder: IShellItem) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IFileOperation.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.CopyItems(pThis, punkItems.pUnk,
+                                                RawPointer(psiDestinationFolder))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IFileOperation.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.CopyItems(pThis, punkItems.pUnk,
-                                               RawPointer(psiDestinationFolder))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func DeleteItem(_ psiItem: IShellItem,
                          _ pfopsItem: IFileOperationProgressSink?) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IFileOperation.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.DeleteItem(pThis, RawPointer(psiItem),
+                                                  RawPointer(pfopsItem))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IFileOperation.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.DeleteItem(pThis, RawPointer(psiItem),
-                                                RawPointer(pfopsItem))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func DeleteItems(_ punkItems: IUnknown) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IFileOperation.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.DeleteItems(pThis, punkItems.pUnk)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IFileOperation.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.DeleteItems(pThis, punkItems.pUnk)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func GetAnyOperationsAborted() throws -> Bool {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IFileOperation.self) { pThis in
+      var fAnyOperationsAborted: WindowsBool = false
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetAnyOperationsAborted(pThis,
+                                                               &fAnyOperationsAborted)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return fAnyOperationsAborted == true
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IFileOperation.self, capacity: 1)
-
-    var fAnyOperationsAborted: WindowsBool = false
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee
-                          .GetAnyOperationsAborted(pThis, &fAnyOperationsAborted)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return fAnyOperationsAborted == true
   }
 
   public func MoveItem(_ psiItem: IShellItem,
                        _ psiDestinationFolder: IShellItem,
                        _ pszNewName: String?,
                        _ pfopsItem: IFileOperationProgressSink?) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IFileOperation.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.MoveItem(pThis, RawPointer(psiItem),
+                                                RawPointer(psiDestinationFolder),
+                                                pszNewName?.wide,
+                                                RawPointer(pfopsItem))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IFileOperation.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.MoveItem(pThis, RawPointer(psiItem),
-                                              RawPointer(psiDestinationFolder),
-                                              pszNewName?.wide,
-                                              RawPointer(pfopsItem))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func MoveItems(_ punkItems: IUnknown,
                         _ psiDestinationFolder: IShellItem) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IFileOperation.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.MoveItems(pThis, punkItems.pUnk,
+                                                RawPointer(psiDestinationFolder))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IFileOperation.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.MoveItems(pThis, punkItems.pUnk,
-                                               RawPointer(psiDestinationFolder))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func NewItem(_ psiDestinationFolder: IShellItem,
                       _ dwFileAttributes: DWORD, _ pszName: String,
                       _ pszTemplateName: String?,
                       _ pfopsItem: IFileOperationProgressSink?) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IFileOperation.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.NewItem(pThis,
+                                              RawPointer(psiDestinationFolder),
+                                              dwFileAttributes, pszName.wide,
+                                              pszTemplateName?.wide,
+                                              RawPointer(pfopsItem))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IFileOperation.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.NewItem(pThis,
-                                             RawPointer(psiDestinationFolder),
-                                             dwFileAttributes, pszName.wide,
-                                             pszTemplateName?.wide,
-                                             RawPointer(pfopsItem))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func PerformOperations() throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IFileOperation.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.PerformOperations(pThis)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IFileOperation.self, capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.PerformOperations(pThis)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func RenameItem(_ psiItem: IShellItem, _ pszNewName: String,
                          _ pfopsItem: IFileOperationProgressSink?) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IFileOperation.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.RenameItem(pThis, RawPointer(psiItem),
+                                                  pszNewName.wide,
+                                                  RawPointer(pfopsItem))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IFileOperation.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.RenameItem(pThis, RawPointer(psiItem),
-                                                pszNewName.wide,
-                                                RawPointer(pfopsItem))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func RenameItems(_ pUnkItems: IUnknown,
                           _ pszNewName: String) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IFileOperation.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.RenameItems(pThis, pUnkItems.pUnk,
+                                                  pszNewName.wide)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IFileOperation.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.RenameItems(pThis, pUnkItems.pUnk,
-                                                 pszNewName.wide)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetOperationFlags(_ dwOperationFlags: DWORD) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IFileOperation.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.SetOperationFlags(pThis,
+                                                         dwOperationFlags)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IFileOperation.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetOperationFlags(pThis, dwOperationFlags)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetOwnerWindow(_ hwndOwner: HWND) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IFileOperation.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.SetOwnerWindow(pThis, hwndOwner)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IFileOperation.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetOwnerWindow(pThis, hwndOwner)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetProgressDialog(_ popd: IOperationsProgressDialog) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IFileOperation.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.SetProgressDialog(pThis,
+                                                         RawPointer(popd))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IFileOperation.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetProgressDialog(pThis, RawPointer(popd))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetProgressMessage(_ pszMessage: String) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IFileOperation.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.SetProgressMessage(pThis,
+                                                          pszMessage.wide)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IFileOperation.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetProgressMessage(pThis, pszMessage.wide)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetProperties(_ ppropArray: IPropertyChangeArray) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IFileOperation.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.SetProperties(pThis,
+                                                     RawPointer(ppropArray))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IFileOperation.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetProperties(pThis, RawPointer(ppropArray))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func Unadvise(_ dwCookie: DWORD) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IFileOperation.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Unadvise(pThis, dwCookie)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IFileOperation.self, capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Unadvise(pThis, dwCookie)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IMalloc.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IMalloc.swift
@@ -11,57 +11,39 @@ public class IMalloc: IUnknown {
   override public class var IID: IID { IID_IMalloc }
 
   public func Alloc(_ cb: SIZE_T) throws -> UnsafeMutableRawPointer? {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IMalloc.self) { pThis in
+      return pThis.pointee.lpVtbl.pointee.Alloc(pThis, cb)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IMalloc.self, capacity: 1)
-
-    return pThis.pointee.lpVtbl.pointee.Alloc(pThis, cb)
   }
 
   public func DidAlloc(_ pv: UnsafeMutableRawPointer?) throws -> CInt {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IMalloc.self) { pThis in
+      return pThis.pointee.lpVtbl.pointee.DidAlloc(pThis, pv)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IMalloc.self, capacity: 1)
-
-    return pThis.pointee.lpVtbl.pointee.DidAlloc(pThis, pv)
   }
 
   public func Free(_ pv: UnsafeMutableRawPointer?) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IMalloc.self) { pThis in
+      return pThis.pointee.lpVtbl.pointee.Free(pThis, pv)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IMalloc.self, capacity: 1)
-
-    return pThis.pointee.lpVtbl.pointee.Free(pThis, pv)
   }
 
   public func GetSize(_ pv: UnsafeMutableRawPointer?) throws -> SIZE_T {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IMalloc.self) { pThis in
+      return pThis.pointee.lpVtbl.pointee.GetSize(pThis, pv)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IMalloc.self, capacity: 1)
-
-    return pThis.pointee.lpVtbl.pointee.GetSize(pThis, pv)
   }
 
   public func HeapMinimize() throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IMalloc.self) { pThis in
+      return pThis.pointee.lpVtbl.pointee.HeapMinimize(pThis)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IMalloc.self, capacity: 1)
-
-    return pThis.pointee.lpVtbl.pointee.HeapMinimize(pThis)
   }
 
   public func Realloc(_ pv: UnsafeMutableRawPointer?, _ cb: SIZE_T)
       throws -> UnsafeMutableRawPointer? {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IMalloc.self) { pThis in
+      return pThis.pointee.lpVtbl.pointee.Realloc(pThis, pv, cb)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IMalloc.self, capacity: 1)
-
-    return pThis.pointee.lpVtbl.pointee.Realloc(pThis, pv, cb)
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IMoniker.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IMoniker.swift
@@ -12,240 +12,195 @@ public class IMoniker: IPersistStream {
 
   public func BindToObject(_ pbc: IBindCtx, _ pmkToLeft: IMoniker,
                            _ riidResult: IID) throws -> IUnknown {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IMoniker.self) { pThis in
+      var iid: IID = riidResult
+      var pvResult: UnsafeMutableRawPointer?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.BindToObject(pThis, RawPointer(pbc),
+                                                    RawPointer(pmkToLeft),
+                                                    &iid, &pvResult)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IUnknown(pUnk: pvResult)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IMoniker.self, capacity: 1)
-
-    var iid: IID = riidResult
-    var pvResult: UnsafeMutableRawPointer?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.BindToObject(pThis, RawPointer(pbc),
-                                                  RawPointer(pmkToLeft),
-                                                  &iid, &pvResult)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IUnknown(pUnk: pvResult)
   }
 
   public func BindToStorage(_ pbc: IBindCtx, _ pmkToLeft: IMoniker,
                             _ riid: inout IID) throws -> IUnknown {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IMoniker.self) { pThis in
+      var pvObj: UnsafeMutableRawPointer?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.BindToObject(pThis, RawPointer(pbc),
+                                                    RawPointer(pmkToLeft),
+                                                    &riid, &pvObj)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IUnknown(pUnk: pvObj)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IMoniker.self, capacity: 1)
-
-    var pvObj: UnsafeMutableRawPointer?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.BindToObject(pThis, RawPointer(pbc),
-                                                  RawPointer(pmkToLeft),
-                                                  &riid, &pvObj)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IUnknown(pUnk: pvObj)
   }
 
   public func CommonPrefixWith(_ pmkOther: IMoniker) throws -> IMoniker {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IMoniker.self) { pThis in
+      var pmkPrefix: UnsafeMutablePointer<WinSDK.IMoniker>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.CommonPrefixWith(pThis,
+                                                        RawPointer(pmkOther),
+                                                        &pmkPrefix)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IMoniker(pUnk: pmkPrefix)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IMoniker.self, capacity: 1)
-
-    var pmkPrefix: UnsafeMutablePointer<WinSDK.IMoniker>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.CommonPrefixWith(pThis,
-                                                      RawPointer(pmkOther),
-                                                      &pmkPrefix)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IMoniker(pUnk: pmkPrefix)
   }
 
   public func ComposeWith(_ pmkRight: IMoniker, _ fOnlyIfNotGeneric: Bool)
       throws -> IMoniker {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IMoniker.self) { pThis in
+      var pmkComposite: UnsafeMutablePointer<WinSDK.IMoniker>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.ComposeWith(pThis, RawPointer(pmkRight),
+                                                  WindowsBool(fOnlyIfNotGeneric == true),
+                                                  &pmkComposite)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IMoniker(pUnk: pmkComposite)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IMoniker.self, capacity: 1)
-
-    var pmkComposite: UnsafeMutablePointer<WinSDK.IMoniker>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.ComposeWith(pThis, RawPointer(pmkRight),
-                                                 WindowsBool(fOnlyIfNotGeneric == true),
-                                                 &pmkComposite)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IMoniker(pUnk: pmkComposite)
   }
 
   public func Enum(_ fForward: Bool) throws -> IEnumMoniker {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IMoniker.self) { pThis in
+      var penumMoniker: UnsafeMutablePointer<WinSDK.IEnumMoniker>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.Enum(pThis, WindowsBool(fForward == true),
+                                            &penumMoniker)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IEnumMoniker(pUnk: penumMoniker)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IMoniker.self, capacity: 1)
-
-    var penumMoniker: UnsafeMutablePointer<WinSDK.IEnumMoniker>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.Enum(pThis, WindowsBool(fForward == true),
-                                          &penumMoniker)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IEnumMoniker(pUnk: penumMoniker)
   }
 
   public func GetDisplayName(_ pbc: IBindCtx, _ pmkToLeft: IMoniker?)
       throws -> String {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IMoniker.self) { pThis in
+      let malloc: IMalloc = try CoGetMalloc()
+      defer { _ = try? malloc.Release() }
+
+      var pszDisplayName: LPOLESTR?
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee
+                            .GetDisplayName(pThis, RawPointer(pbc),
+                                            RawPointer(pmkToLeft), &pszDisplayName)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+
+      defer { try? malloc.Free(pszDisplayName) }
+      return String(decodingCString: pszDisplayName!, as: UTF16.self)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IMoniker.self, capacity: 1)
-
-    let malloc: IMalloc = try CoGetMalloc()
-    defer { _ = try? malloc.Release() }
-
-    var pszDisplayName: LPOLESTR?
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee
-                          .GetDisplayName(pThis, RawPointer(pbc),
-                                          RawPointer(pmkToLeft), &pszDisplayName)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-
-    defer { try? malloc.Free(pszDisplayName) }
-    return String(decodingCString: pszDisplayName!, as: UTF16.self)
   }
 
   public func GetTimeOfLastChange(_ pbc: IBindCtx, _ pmkToLeft: IMoniker)
       throws -> FILETIME {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IMoniker.self) { pThis in
+      var FileTime: FILETIME = FILETIME()
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee
+                            .GetTimeOfLastChange(pThis, RawPointer(pbc),
+                                                RawPointer(pmkToLeft), &FileTime)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return FileTime
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IMoniker.self, capacity: 1)
-
-    var FileTime: FILETIME = FILETIME()
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee
-                          .GetTimeOfLastChange(pThis, RawPointer(pbc),
-                                               RawPointer(pmkToLeft), &FileTime)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return FileTime
   }
 
   public func Hash() throws -> DWORD {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IMoniker.self) { pThis in
+      var dwHash: DWORD = 0
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Hash(pThis, &dwHash)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return dwHash
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IMoniker.self, capacity: 1)
-
-    var dwHash: DWORD = 0
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Hash(pThis, &dwHash)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return dwHash
   }
 
   public func Inverse() throws -> IMoniker {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IMoniker.self) { pThis in
+      var pmk: UnsafeMutablePointer<WinSDK.IMoniker>?
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Inverse(pThis, &pmk)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IMoniker(pUnk: pmk)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IMoniker.self, capacity: 1)
-
-    var pmk: UnsafeMutablePointer<WinSDK.IMoniker>?
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Inverse(pThis, &pmk)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IMoniker(pUnk: pmk)
   }
 
   public func IsEqual(_ pmkOtherMoniker: IMoniker) throws -> Bool {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis = pUnk.bindMemory(to: WinSDK.IMoniker.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.IsEqual(pThis, RawPointer(pmkOtherMoniker))
-    switch hr {
-    case S_OK: return true
-    case S_FALSE: return false
-    default: throw COMError(hr: hr)
+    return try perform(as: WinSDK.IMoniker.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.IsEqual(pThis, RawPointer(pmkOtherMoniker))
+      switch hr {
+      case S_OK: return true
+      case S_FALSE: return false
+      default: throw COMError(hr: hr)
+      }
     }
   }
 
   public func IsRunning(_ pbc: IBindCtx, _ pmkToLeft: IMoniker?,
                         _ pmkNewlyRunning: IMoniker?) throws -> Bool {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis = pUnk.bindMemory(to: WinSDK.IMoniker.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.IsRunning(pThis, RawPointer(pbc),
-                                               RawPointer(pmkToLeft),
-                                               RawPointer(pmkNewlyRunning))
-    switch hr {
-    case S_OK: return true
-    case S_FALSE: return false
-    default: throw COMError(hr: hr)
+    return try perform(as: WinSDK.IMoniker.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.IsRunning(pThis, RawPointer(pbc),
+                                                RawPointer(pmkToLeft),
+                                                RawPointer(pmkNewlyRunning))
+      switch hr {
+      case S_OK: return true
+      case S_FALSE: return false
+      default: throw COMError(hr: hr)
+      }
     }
   }
 
   public func IsSystemMoniker() throws -> DWORD {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis = pUnk.bindMemory(to: WinSDK.IMoniker.self, capacity: 1)
-
-    var dwMksys: DWORD = 0
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.IsSystemMoniker(pThis, &dwMksys)
-    switch hr {
-    case S_OK: return dwMksys
-    case S_FALSE: return DWORD(MKSYS_NONE.rawValue)
-    default: throw COMError(hr: hr)
+    return try perform(as: WinSDK.IMoniker.self) { pThis in
+      var dwMksys: DWORD = 0
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.IsSystemMoniker(pThis, &dwMksys)
+      switch hr {
+      case S_OK: return dwMksys
+      case S_FALSE: return DWORD(MKSYS_NONE.rawValue)
+      default: throw COMError(hr: hr)
+      }
     }
   }
 
   public func ParseDisplayName(_ pbc: IBindCtx, _ pmkToLeft: IMoniker,
                                _ pszDisplayName: String)
       throws -> (Int, IMoniker) {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IMoniker.self) { pThis in
+      var chEaten: ULONG = 0
+      var pmkOut: UnsafeMutablePointer<WinSDK.IMoniker>?
+      var olestr: [OLECHAR] = pszDisplayName.wide
+      let hr: HRESULT = olestr.withUnsafeMutableBufferPointer {
+        pThis.pointee.lpVtbl.pointee
+            .ParseDisplayName(pThis, RawPointer(pbc), RawPointer(pmkToLeft),
+                              $0.baseAddress, &chEaten, &pmkOut)
+      }
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return (Int(chEaten), IMoniker(pUnk: pmkOut))
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IMoniker.self, capacity: 1)
-
-    var chEaten: ULONG = 0
-    var pmkOut: UnsafeMutablePointer<WinSDK.IMoniker>?
-    var olestr: [OLECHAR] = pszDisplayName.wide
-    let hr: HRESULT = olestr.withUnsafeMutableBufferPointer {
-      pThis.pointee.lpVtbl.pointee
-          .ParseDisplayName(pThis, RawPointer(pbc), RawPointer(pmkToLeft),
-                            $0.baseAddress, &chEaten, &pmkOut)
-    }
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return (Int(chEaten), IMoniker(pUnk: pmkOut))
   }
 
   public func Reduce(_ pbc: IBindCtx, _ dwReduceHowFar: DWORD,
                      _ pmkToLeft: inout IMoniker) throws -> IMoniker {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IMoniker.self) { pThis in
+      var ppmkToLeft: UnsafeMutablePointer<WinSDK.IMoniker>? =
+          RawPointer(pmkToLeft)
+      var pmkReduced: UnsafeMutablePointer<WinSDK.IMoniker>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.Reduce(pThis, RawPointer(pbc),
+                                              dwReduceHowFar, &ppmkToLeft,
+                                              &pmkReduced)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      pmkToLeft = IMoniker(pUnk: ppmkToLeft)
+      return IMoniker(pUnk: pmkReduced)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IMoniker.self, capacity: 1)
-
-    var ppmkToLeft: UnsafeMutablePointer<WinSDK.IMoniker>? =
-        RawPointer(pmkToLeft)
-    var pmkReduced: UnsafeMutablePointer<WinSDK.IMoniker>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.Reduce(pThis, RawPointer(pbc),
-                                            dwReduceHowFar, &ppmkToLeft,
-                                            &pmkReduced)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    pmkToLeft = IMoniker(pUnk: ppmkToLeft)
-    return IMoniker(pUnk: pmkReduced)
   }
 
   public func RelativePathTo(_ pmkOther: IMoniker) throws -> IMoniker {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IMoniker.self) { pThis in
+      var pmkRelPath: UnsafeMutablePointer<WinSDK.IMoniker>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.RelativePathTo(pThis, RawPointer(pmkOther),
+                                                      &pmkRelPath)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IMoniker(pUnk: pmkRelPath)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IMoniker.self, capacity: 1)
-
-    var pmkRelPath: UnsafeMutablePointer<WinSDK.IMoniker>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.RelativePathTo(pThis, RawPointer(pmkOther),
-                                                    &pmkRelPath)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IMoniker(pUnk: pmkRelPath)
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IObjectWithPropertyKey.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IObjectWithPropertyKey.swift
@@ -11,26 +11,18 @@ public class IObjectWithPropertyKey: IUnknown {
   override public class var IID: IID { IID_IObjectWithPropertyKey }
 
   public func GetPropertyKey() throws -> PROPERTYKEY {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IObjectWithPropertyKey.self) { pThis in
+      var key: PROPERTYKEY = PROPERTYKEY()
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetPropertyKey(pThis, &key)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return key
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IObjectWithPropertyKey.self, capacity: 1)
-
-    var key: PROPERTYKEY = PROPERTYKEY()
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetPropertyKey(pThis, &key)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return key
   }
 
   public func SetPropertyKey(_ key: REFPROPERTYKEY) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IObjectWithPropertyKey.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.SetPropertyKey(pThis, key)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IObjectWithPropertyKey.self, capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.SetPropertyKey(pThis, key)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IOperationsProgressDialog.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IOperationsProgressDialog.swift
@@ -11,127 +11,87 @@ public class IOperationsProgressDialog: IUnknown {
   override public class var IID: IID { IID_IOperationsProgressDialog }
 
   public func GetMilliseconds() throws -> (ULONGLONG, ULONGLONG) {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IOperationsProgressDialog.self) { pThis in
+      var ullElapsed: ULONGLONG = 0
+      var ullRemaining: ULONGLONG = 0
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetMilliseconds(pThis, &ullElapsed,
+                                                      &ullRemaining)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return (ullElapsed, ullRemaining)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IOperationsProgressDialog.self,
-                                capacity: 1)
-
-    var ullElapsed: ULONGLONG = 0
-    var ullRemaining: ULONGLONG = 0
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetMilliseconds(pThis, &ullElapsed,
-                                                     &ullRemaining)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return (ullElapsed, ullRemaining)
   }
 
   public func GetOperationStatus() throws -> PDOPSTATUS {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IOperationsProgressDialog.self) { pThis in
+      var opstatus: PDOPSTATUS = PDOPSTATUS(0)
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetOperationStatus(pThis, &opstatus)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return opstatus
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IOperationsProgressDialog.self,
-                                capacity: 1)
-
-    var opstatus: PDOPSTATUS = PDOPSTATUS(0)
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetOperationStatus(pThis, &opstatus)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return opstatus
   }
 
   public func PauseTimer() throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IOperationsProgressDialog.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.PauseTimer(pThis)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IOperationsProgressDialog.self,
-                                capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.PauseTimer(pThis)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func ResetTimer() throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IOperationsProgressDialog.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.ResetTimer(pThis)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IOperationsProgressDialog.self,
-                                capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.ResetTimer(pThis)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func ResumeTimer() throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IOperationsProgressDialog.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.ResumeTimer(pThis)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IOperationsProgressDialog.self,
-                                capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.ResumeTimer(pThis)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetMode(_ mode: PDMODE) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IOperationsProgressDialog.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.SetMode(pThis, mode)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IOperationsProgressDialog.self,
-                                capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.SetMode(pThis, mode)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetOperation(_ action: SPACTION) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IOperationsProgressDialog.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.SetOperation(pThis, action)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IOperationsProgressDialog.self,
-                                capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.SetOperation(pThis, action)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func StartProgressDialog(_ hwnd: HWND, _ flags: OPPROGDLGF) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IOperationsProgressDialog.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.StartProgressDialog(pThis, hwnd, flags)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IOperationsProgressDialog.self,
-                                capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.StartProgressDialog(pThis, hwnd, flags)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func StopProgressDialog() throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IOperationsProgressDialog.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.StopProgressDialog(pThis)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IOperationsProgressDialog.self,
-                                capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.StopProgressDialog(pThis)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func UpdateLocations(_ psiSource: IShellItem, _ psiTarget: IShellItem,
                               _ psiItem: IShellItem) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IOperationsProgressDialog.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.UpdateLocations(pThis,
+                                                      RawPointer(psiSource),
+                                                      RawPointer(psiTarget),
+                                                      RawPointer(psiItem))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IOperationsProgressDialog.self,
-                                capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.UpdateLocations(pThis,
-                                                     RawPointer(psiSource),
-                                                     RawPointer(psiTarget),
-                                                     RawPointer(psiItem))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func UpdateProgress(_ ullPointsCurrent: ULONGLONG,
@@ -140,19 +100,15 @@ public class IOperationsProgressDialog: IUnknown {
                              _ ullSizeTotal: ULONGLONG,
                              _ ullItemsCurrent: ULONGLONG,
                              _ ullItemsTotal: ULONGLONG) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IOperationsProgressDialog.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.UpdateProgress(pThis, ullPointsCurrent,
+                                                      ullPointsTotal,
+                                                      ullSizeCurrent,
+                                                      ullSizeTotal,
+                                                      ullItemsCurrent,
+                                                      ullItemsTotal)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IOperationsProgressDialog.self,
-                                capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.UpdateProgress(pThis, ullPointsCurrent,
-                                                    ullPointsTotal,
-                                                    ullSizeCurrent,
-                                                    ullSizeTotal,
-                                                    ullItemsCurrent,
-                                                    ullItemsTotal)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IPersist.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IPersist.swift
@@ -11,14 +11,11 @@ public class IPersist: IPersistStream {
   override public class var IID: IID { IID_IPersist }
 
   public func GetClassID() throws -> CLSID {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPersist.self) { pThis in
+      var ClassID: CLSID = CLSID()
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetClassID(pThis, &ClassID)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return ClassID
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IPersist.self, capacity: 1)
-
-    var ClassID: CLSID = CLSID()
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetClassID(pThis, &ClassID)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return ClassID
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IPersistStream.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IPersistStream.swift
@@ -11,50 +11,38 @@ public class IPersistStream: IUnknown {
   override public class var IID: IID { IID_IPersistStream }
 
   public func GetSizeMax() throws -> ULARGE_INTEGER {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPersistStream.self) { pThis in
+      var cbSize: ULARGE_INTEGER = ULARGE_INTEGER()
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetSizeMax(pThis, &cbSize)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return cbSize
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IPersistStream.self, capacity: 1)
-
-    var cbSize: ULARGE_INTEGER = ULARGE_INTEGER()
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetSizeMax(pThis, &cbSize)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return cbSize
   }
 
   public func IsDirty() throws -> Bool {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis = pUnk.bindMemory(to: WinSDK.IPersistStream.self, capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.IsDirty(pThis)
-    switch hr {
-    case S_OK: return true
-    case S_FALSE: return false
-    default: throw COMError(hr: hr)
+    return try perform(as: WinSDK.IPersistStream.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.IsDirty(pThis)
+      switch hr {
+      case S_OK: return true
+      case S_FALSE: return false
+      default: throw COMError(hr: hr)
+      }
     }
   }
 
   public func Load(_ pStm: IStream) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPersistStream.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Load(pThis, RawPointer(pStm))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IPersistStream.self, capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Load(pThis, RawPointer(pStm))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func Save(_ pStm: IStream, _ fClearDirty: Bool) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPersistStream.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.Save(pThis, RawPointer(pStm),
+                                            WindowsBool(fClearDirty == true))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IPersistStream.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.Save(pThis, RawPointer(pStm),
-                                          WindowsBool(fClearDirty == true))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IPortableDeviceKeyCollection.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IPortableDeviceKeyCollection.swift
@@ -11,62 +11,41 @@ public class IPortableDeviceKeyCollection: IUnknown {
   override public class var IID: IID { IID_IPortableDeviceKeyCollection }
 
   public func Add(_ Key: REFPROPERTYKEY) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceKeyCollection.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Add(pThis, Key)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IPortableDeviceKeyCollection.self,
-                                capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Add(pThis, Key)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func Clear() throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceKeyCollection.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Clear(pThis)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IPortableDeviceKeyCollection.self,
-                                capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Clear(pThis)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
-  public func GetAt(_ dwIndex: DWORD) throws -> PROPVARIANT {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+  public func GetAt(_ dwIndex: DWORD) throws -> PROPERTYKEY {
+    return try perform(as: WinSDK.IPortableDeviceKeyCollection.self) { pThis in
+      var Key: PROPERTYKEY = PROPERTYKEY()
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetAt(pThis, dwIndex, &Key)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return Key
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDevicePropVariantCollection.self,
-                        capacity: 1)
-
-    var Key: PROPVARIANT = PROPVARIANT()
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetAt(pThis, dwIndex, &Key)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return Key
   }
 
   public func GetCount() throws -> DWORD {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceKeyCollection.self) { pThis in
+      var cElems: DWORD = DWORD(0)
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetCount(pThis, &cElems)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return cElems
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IPortableDeviceKeyCollection.self,
-                                capacity: 1)
-
-    var cElems: DWORD = DWORD(0)
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetCount(pThis, &cElems)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return cElems
   }
 
   public func RemoveAt(_ dwIndex: DWORD) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceKeyCollection.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.RemoveAt(pThis, dwIndex)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IPortableDeviceKeyCollection.self,
-                                capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.RemoveAt(pThis, dwIndex)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IPortableDevicePropVariantCollection.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IPortableDevicePropVariantCollection.swift
@@ -11,95 +11,60 @@ public class IPortableDevicePropVariantCollection: IUnknown {
   override public class var IID: IID { IID_IPortableDevicePropVariantCollection }
 
   public func Add(_ value: PROPVARIANT) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDevicePropVariantCollection.self) { pThis in
+      var value = value
+      let hr: HRESULT = withUnsafePointer(to: &value) {
+        pThis.pointee.lpVtbl.pointee.Add(pThis, $0)
+      }
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDevicePropVariantCollection.self,
-                        capacity: 1)
-
-    var value = value
-    let hr: HRESULT = withUnsafePointer(to: &value) {
-      pThis.pointee.lpVtbl.pointee.Add(pThis, $0)
-    }
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func ChangeType(_ vt: VARTYPE) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDevicePropVariantCollection.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.ChangeType(pThis, vt)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDevicePropVariantCollection.self,
-                        capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.ChangeType(pThis, vt)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func Clear() throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDevicePropVariantCollection.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Clear(pThis)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDevicePropVariantCollection.self,
-                        capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Clear(pThis)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func GetAt(_ dwIndex: DWORD) throws -> PROPVARIANT {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDevicePropVariantCollection.self) { pThis in
+      var Value: PROPVARIANT = PROPVARIANT()
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetAt(pThis, dwIndex, &Value)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return Value
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDevicePropVariantCollection.self,
-                        capacity: 1)
-
-    var Value: PROPVARIANT = PROPVARIANT()
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetAt(pThis, dwIndex, &Value)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return Value
   }
 
   public func GetCount() throws -> DWORD {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDevicePropVariantCollection.self) { pThis in
+      var cElems: DWORD = DWORD(0)
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetCount(pThis, &cElems)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return cElems
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDevicePropVariantCollection.self,
-                        capacity: 1)
-
-    var cElems: DWORD = DWORD(0)
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetCount(pThis, &cElems)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return cElems
   }
 
   public func GetType() throws -> VARTYPE {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDevicePropVariantCollection.self) { pThis in
+      var vt: VARTYPE = VARTYPE()
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetType(pThis, &vt)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return vt
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDevicePropVariantCollection.self,
-                        capacity: 1)
-
-    var vt: VARTYPE = VARTYPE()
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetType(pThis, &vt)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return vt
   }
 
   public func RemoveAt(_ dwIndex: DWORD) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDevicePropVariantCollection.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.RemoveAt(pThis, dwIndex)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDevicePropVariantCollection.self,
-                        capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.RemoveAt(pThis, dwIndex)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IPortableDeviceValues.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IPortableDeviceValues.swift
@@ -11,569 +11,409 @@ public class IPortableDeviceValues: IUnknown {
   override public class var IID: IID { IID_IPortableDeviceValues }
 
   public func Clear() throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Clear(pThis)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Clear(pThis)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func CopyValuesFromPropertyStore(_ pStore: IPropertyStore) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.CopyValuesFromPropertyStore(pThis,
+                                                                  RawPointer(pStore))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.CopyValuesFromPropertyStore(pThis,
-                                                                 RawPointer(pStore))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func CopyValuesToPropertyStore(_ pStore: IPropertyStore) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.CopyValuesToPropertyStore(pThis,
+                                                                RawPointer(pStore))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.CopyValuesToPropertyStore(pThis,
-                                                               RawPointer(pStore))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func GetAt(_ index: DWORD) throws -> (PROPERTYKEY, PROPVARIANT) {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      var Key: PROPERTYKEY = PROPERTYKEY()
+      var Value: PROPVARIANT = PROPVARIANT()
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &Key, &Value)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return (Key, Value)
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    var Key: PROPERTYKEY = PROPERTYKEY()
-    var Value: PROPVARIANT = PROPVARIANT()
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &Key, &Value)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return (Key, Value)
   }
 
   public func GetBoolValue(_ key: REFPROPERTYKEY) throws -> Bool {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      var Value: WindowsBool = false
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetBoolValue(pThis, key, &Value)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return Value == true
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    var Value: WindowsBool = false
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetBoolValue(pThis, key, &Value)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return Value == true
   }
 
   public func GetBufferValue(_ key: REFPROPERTYKEY) throws -> [BYTE] {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      var pValue: UnsafeMutablePointer<BYTE>?
+      var cbValue: DWORD = DWORD(0)
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetBufferValue(pThis, key, &pValue,
+                                                      &cbValue)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+
+      defer { CoTaskMemFree(pValue) }
+      return Array(UnsafeBufferPointer<BYTE>(start: pValue, count: Int(cbValue)))
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    var pValue: UnsafeMutablePointer<BYTE>?
-    var cbValue: DWORD = DWORD(0)
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetBufferValue(pThis, key, &pValue,
-                                                    &cbValue)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-
-    defer { CoTaskMemFree(pValue) }
-    return Array(UnsafeBufferPointer<BYTE>(start: pValue, count: Int(cbValue)))
   }
 
   public func GetCount() throws -> DWORD {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      var celt: DWORD = DWORD(0)
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetCount(pThis, &celt)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return celt
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    var celt: DWORD = DWORD(0)
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetCount(pThis, &celt)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return celt
   }
 
   public func GetErrorValue(_ key: REFPROPERTYKEY) throws -> HRESULT {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      var Value: HRESULT = S_OK
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetErrorValue(pThis, key, &Value)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return Value
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    var Value: HRESULT = S_OK
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetErrorValue(pThis, key, &Value)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return Value
   }
 
   public func GetFloatValue(_ key: REFPROPERTYKEY) throws -> FLOAT {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      var Value: FLOAT = FLOAT()
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetFloatValue(pThis, key, &Value)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return Value
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    var Value: FLOAT = FLOAT()
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetFloatValue(pThis, key, &Value)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return Value
   }
 
   public func GetGuidValue(_ key: REFPROPERTYKEY) throws -> GUID {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      var Value: GUID = GUID()
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetGuidValue(pThis, key, &Value)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return Value
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    var Value: GUID = GUID()
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetGuidValue(pThis, key, &Value)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return Value
   }
 
   public func GetIPortableDeviceKeyCollectionValue(_ key: REFPROPERTYKEY)
       throws -> IPortableDeviceKeyCollection {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      var pValue: UnsafeMutablePointer<WinSDK.IPortableDeviceKeyCollection>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetIPortableDeviceKeyCollectionValue(pThis,
+                                                                            key,
+                                                                            &pValue)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IPortableDeviceKeyCollection(pUnk: pValue)
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    var pValue: UnsafeMutablePointer<WinSDK.IPortableDeviceKeyCollection>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetIPortableDeviceKeyCollectionValue(pThis,
-                                                                          key,
-                                                                          &pValue)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IPortableDeviceKeyCollection(pUnk: pValue)
   }
 
   public func GetIPortableDevicePropVariantCollectionValue(_ key: REFPROPERTYKEY)
       throws -> IPortableDevicePropVariantCollection {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      var pValue: UnsafeMutablePointer<WinSDK.IPortableDevicePropVariantCollection>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetIPortableDevicePropVariantCollectionValue(pThis,
+                                                                                    key,
+                                                                                    &pValue)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IPortableDevicePropVariantCollection(pUnk: pValue)
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    var pValue: UnsafeMutablePointer<WinSDK.IPortableDevicePropVariantCollection>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetIPortableDevicePropVariantCollectionValue(pThis,
-                                                                                  key,
-                                                                                  &pValue)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IPortableDevicePropVariantCollection(pUnk: pValue)
   }
 
   public func GetIPortableDeviceValuesCollectionValue(_ key: REFPROPERTYKEY)
       throws -> IPortableDeviceValuesCollection {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      var pValue: UnsafeMutablePointer<WinSDK.IPortableDeviceValuesCollection>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetIPortableDeviceValuesCollectionValue(pThis,
+                                                                              key,
+                                                                              &pValue)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IPortableDeviceValuesCollection(pUnk: pValue)
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    var pValue: UnsafeMutablePointer<WinSDK.IPortableDeviceValuesCollection>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetIPortableDeviceValuesCollectionValue(pThis,
-                                                                             key,
-                                                                             &pValue)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IPortableDeviceValuesCollection(pUnk: pValue)
   }
 
   public func GetIPortableDeviceValuesValue(_ key: REFPROPERTYKEY)
       throws -> IPortableDeviceValues {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      var pValue: UnsafeMutablePointer<WinSDK.IPortableDeviceValues>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetIPortableDeviceValuesValue(pThis, key,
+                                                                    &pValue)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IPortableDeviceValues(pUnk: pValue)
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    var pValue: UnsafeMutablePointer<WinSDK.IPortableDeviceValues>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetIPortableDeviceValuesValue(pThis, key,
-                                                                   &pValue)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IPortableDeviceValues(pUnk: pValue)
   }
 
   public func GetIUnknownValue(_ key: REFPROPERTYKEY) throws -> IUnknown {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      var pValue: UnsafeMutablePointer<WinSDK.IUnknown>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetIUnknownValue(pThis, key, &pValue)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IUnknown(pUnk: pValue)
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    var pValue: UnsafeMutablePointer<WinSDK.IUnknown>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetIUnknownValue(pThis, key, &pValue)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IUnknown(pUnk: pValue)
   }
 
   public func GetKeyValue(_ key: REFPROPERTYKEY) throws -> PROPERTYKEY {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      var Value: PROPERTYKEY = PROPERTYKEY()
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetKeyValue(pThis, key, &Value)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return Value
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    var Value: PROPERTYKEY = PROPERTYKEY()
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetKeyValue(pThis, key, &Value)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return Value
   }
 
   public func GetSignedIntegerValue(_ key: REFPROPERTYKEY) throws -> LONG {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      var Value: LONG = LONG()
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetSignedIntegerValue(pThis, key, &Value)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return Value
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    var Value: LONG = LONG()
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetSignedIntegerValue(pThis, key, &Value)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return Value
   }
 
   public func GetSignedLargeIntegerValue(_ key: REFPROPERTYKEY)
       throws -> LONGLONG {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      var Value: LONGLONG = LONGLONG()
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetSignedLargeIntegerValue(pThis, key,
+                                                                  &Value)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return Value
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    var Value: LONGLONG = LONGLONG()
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetSignedLargeIntegerValue(pThis, key,
-                                                                &Value)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return Value
   }
 
   public func GetStringValue(_ key: REFPROPERTYKEY) throws -> String {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      var Value: UnsafeMutablePointer<WCHAR>?
+      let hr: HRESULT =
+        pThis.pointee.lpVtbl.pointee.GetStringValue(pThis, key, &Value)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+
+      defer { CoTaskMemFree(Value) }
+      return String(decodingCString: Value!, as: UTF16.self)
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    var Value: UnsafeMutablePointer<WCHAR>?
-    let hr: HRESULT =
-      pThis.pointee.lpVtbl.pointee.GetStringValue(pThis, key, &Value)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-
-    defer { CoTaskMemFree(Value) }
-    return String(decodingCString: Value!, as: UTF16.self)
   }
 
   public func GetUnsignedIntegerValue(_ key: REFPROPERTYKEY) throws -> ULONG {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      var Value: ULONG = ULONG()
+      let hr: HRESULT =
+        pThis.pointee.lpVtbl.pointee.GetUnsignedIntegerValue(pThis, key, &Value)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return Value
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    var Value: ULONG = ULONG()
-    let hr: HRESULT =
-      pThis.pointee.lpVtbl.pointee.GetUnsignedIntegerValue(pThis, key, &Value)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return Value
   }
 
   public func GetUnsignedLargeIntegerValue(_ key: REFPROPERTYKEY)
       throws -> ULONGLONG {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      var Value: ULONGLONG = ULONGLONG()
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetUnsignedLargeIntegerValue(pThis, key,
+                                                                    &Value)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return Value
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    var Value: ULONGLONG = ULONGLONG()
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetUnsignedLargeIntegerValue(pThis, key,
-                                                                  &Value)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return Value
   }
 
   public func GetValue(_ key: REFPROPERTYKEY) throws -> PROPVARIANT {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      var Value: PROPVARIANT = PROPVARIANT()
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetValue(pThis, key, &Value)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return Value
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    var Value: PROPVARIANT = PROPVARIANT()
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetValue(pThis, key, &Value)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return Value
   }
 
   public func RemoveValue(_ key: REFPROPERTYKEY) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.RemoveValue(pThis, key)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.RemoveValue(pThis, key)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetBoolValue(_ key: REFPROPERTYKEY, _ value: WindowsBool) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.SetBoolValue(pThis, key, value)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetBoolValue(pThis, key, value)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetBufferValue(_ key: REFPROPERTYKEY, _ value: [BYTE]) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      var value = value
+      let hr: HRESULT = value.withUnsafeMutableBufferPointer {
+        pThis.pointee.lpVtbl.pointee.SetBufferValue(pThis, key, $0.baseAddress,
+                                                    DWORD($0.count))
+      }
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    var value = value
-    let hr: HRESULT = value.withUnsafeMutableBufferPointer {
-      pThis.pointee.lpVtbl.pointee.SetBufferValue(pThis, key, $0.baseAddress,
-                                                  DWORD($0.count))
-    }
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetErrorValue(_ key: REFPROPERTYKEY, _ value: HRESULT) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.SetErrorValue(pThis, key, value)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetErrorValue(pThis, key, value)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetFloatValue(_ key: REFPROPERTYKEY, _ value: FLOAT) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.SetFloatValue(pThis, key, value)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetFloatValue(pThis, key, value)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetGuidValue(_ key: REFPROPERTYKEY, _ value: REFGUID) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.SetGuidValue(pThis, key, value)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetGuidValue(pThis, key, value)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetIPortableDeviceKeyCollectionValue(_ key: REFPROPERTYKEY,
                                                    _ value: IPortableDeviceKeyCollection)
       throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.SetIPortableDeviceKeyCollectionValue(pThis,
+                                                                            key,
+                                                                            RawPointer(value))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetIPortableDeviceKeyCollectionValue(pThis,
-                                                                          key,
-                                                                          RawPointer(value))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetIPortableDevicePropVariantCollectionValue(_ key: REFPROPERTYKEY,
                                                            _ value: IPortableDevicePropVariantCollection)
       throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.SetIPortableDevicePropVariantCollectionValue(pThis,
+                                                                                    key,
+                                                                                    RawPointer(value))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetIPortableDevicePropVariantCollectionValue(pThis,
-                                                                                  key,
-                                                                                  RawPointer(value))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetIPortableDeviceValuesCollectionValue(_ key: REFPROPERTYKEY,
                                                       _ value: IPortableDeviceValuesCollection)
       throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.SetIPortableDeviceValuesCollectionValue(pThis,
+                                                                              key,
+                                                                              RawPointer(value))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetIPortableDeviceValuesCollectionValue(pThis,
-                                                                             key,
-                                                                             RawPointer(value))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetIPortableDeviceValuesValue(_ key: REFPROPERTYKEY,
                                             _ value: IPortableDeviceValues)
       throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.SetIPortableDeviceValuesValue(pThis,
+                                                                    key,
+                                                                    RawPointer(value))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetIPortableDeviceValuesValue(pThis,
-                                                                   key,
-                                                                   RawPointer(value))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetIUnknownValue(_ key: REFPROPERTYKEY, _ value: IUnknown) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.SetIUnknownValue(pThis, key,
+                                                        RawPointer(value))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetIUnknownValue(pThis, key,
-                                                      RawPointer(value))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetKeyValue(_ key: REFPROPERTYKEY, _ value: REFPROPERTYKEY)
       throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.SetKeyValue(pThis, key, value)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.SetKeyValue(pThis, key, value)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetSignedIntegerValue(_ key: REFPROPERTYKEY, _ value: LONG)
       throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.SetSignedIntegerValue(pThis, key, value)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetSignedIntegerValue(pThis, key, value)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetSignedLargeIntegerValue(_ key: REFPROPERTYKEY,
                                          _ value: LONGLONG) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.SetSignedLargeIntegerValue(pThis, key,
+                                                                  value)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetSignedLargeIntegerValue(pThis, key,
-                                                                value)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetStringValue(_ key: REFPROPERTYKEY, _ value: String) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      let hr: HRESULT = value.withCString(encodedAs: UTF16.self) {
+        pThis.pointee.lpVtbl.pointee.SetStringValue(pThis, key, $0)
+      }
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    let hr: HRESULT = value.withCString(encodedAs: UTF16.self) {
-      pThis.pointee.lpVtbl.pointee.SetStringValue(pThis, key, $0)
-    }
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetUnsignedIntegerValue(_ key: REFPROPERTYKEY, _ value: ULONG)
       throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.SetUnsignedIntegerValue(pThis, key, value)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetUnsignedIntegerValue(pThis, key, value)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetUnsignedLargeIntegerValue(_ key: REFPROPERTYKEY,
                                            _ value: ULONGLONG) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.SetUnsignedLargeIntegerValue(pThis, key,
+                                                                    value)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetUnsignedLargeIntegerValue(pThis, key,
-                                                                  value)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetValue(_ key: REFPROPERTYKEY, _ value: PROPVARIANT) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
+      var value = value
+      let hr: HRESULT = withUnsafePointer(to: &value) {
+        pThis.pointee.lpVtbl.pointee.SetValue(pThis, key, $0)
+      }
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPortableDeviceValues.self, capacity: 1)
-
-    var value = value
-    let hr: HRESULT = withUnsafePointer(to: &value) {
-      pThis.pointee.lpVtbl.pointee.SetValue(pThis, key, $0)
-    }
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IPortableDeviceValuesCollection.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IPortableDeviceValuesCollection.swift
@@ -11,63 +11,43 @@ public class IPortableDeviceValuesCollection: IUnknown {
   override public class var IID: IID { IID_IPortableDeviceValuesCollection }
 
   public func Add(_ pValues: IPortableDeviceValues) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValuesCollection.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.Add(pThis, RawPointer(pValues))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IPortableDeviceValuesCollection.self,
-                                capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.Add(pThis, RawPointer(pValues))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func Clear() throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValuesCollection.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Clear(pThis)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IPortableDeviceValuesCollection.self,
-                                capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Clear(pThis)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func GetAt(_ dwIndex: DWORD) throws -> IPortableDeviceValues {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValuesCollection.self) { pThis in
+      var pValues: UnsafeMutablePointer<WinSDK.IPortableDeviceValues>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetAt(pThis, dwIndex, &pValues)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IPortableDeviceValues(pUnk: pValues)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IPortableDeviceValuesCollection.self,
-                                capacity: 1)
-
-    var pValues: UnsafeMutablePointer<WinSDK.IPortableDeviceValues>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetAt(pThis, dwIndex, &pValues)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IPortableDeviceValues(pUnk: pValues)
   }
 
   public func GetCount() throws -> DWORD {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValuesCollection.self) { pThis in
+      var cElems: DWORD = DWORD(0)
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetCount(pThis, &cElems)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return cElems
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IPortableDeviceValuesCollection.self,
-                                capacity: 1)
-
-    var cElems: DWORD = DWORD(0)
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetCount(pThis, &cElems)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return cElems
   }
 
   public func RemoveAt(_ dwIndex: DWORD) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPortableDeviceValuesCollection.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.RemoveAt(pThis, dwIndex)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IPortableDeviceValuesCollection.self,
-                                capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.RemoveAt(pThis, dwIndex)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IPropertyBag2.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IPropertyBag2.swift
@@ -11,93 +11,78 @@ public class IPropertyBag2: IUnknown {
   override public class var IID: IID { IID_IPropertyBag2 }
 
   public func CountProperties() throws -> ULONG {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPropertyBag2.self) { pThis in
+      var cProperties: ULONG = ULONG(0)
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.CountProperties(pThis, &cProperties)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return cProperties
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IPropertyBag2.self, capacity: 1)
-
-    var cProperties: ULONG = ULONG(0)
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.CountProperties(pThis, &cProperties)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return cProperties
   }
 
   public func GetPropertyInfo(_ iProperty: ULONG, _ cProperties: ULONG)
       throws -> [PROPBAG2] {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis = pUnk.bindMemory(to: WinSDK.IPropertyBag2.self, capacity: 1)
-
-    return try Array<PROPBAG2>(unsafeUninitializedCapacity: Int(cProperties)) {
-      var count: ULONG = ULONG(0)
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetPropertyInfo(pThis, iProperty,
-                                                       cProperties,
-                                                       $0.baseAddress, &count)
-      guard hr == S_OK else { throw COMError(hr: hr) }
-      $1 = Int(count)
+    return try perform(as: WinSDK.IPropertyBag2.self) { pThis in
+      return try Array<PROPBAG2>(unsafeUninitializedCapacity: Int(cProperties)) {
+        var count: ULONG = ULONG(0)
+        let hr: HRESULT =
+            pThis.pointee.lpVtbl.pointee.GetPropertyInfo(pThis, iProperty,
+                                                        cProperties,
+                                                        $0.baseAddress, &count)
+        guard hr == S_OK else { throw COMError(hr: hr) }
+        $1 = Int(count)
+      }
     }
   }
 
   public func LoadObject(_ strName: String, _ dwHint: DWORD,
                          _ pUnkObject: IUnknown, _ pErrLog: IErrorLog) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPropertyBag2.self) { pThis in
+      let hr: HRESULT = strName.withCString(encodedAs: UTF16.self) {
+        pThis.pointee.lpVtbl.pointee.LoadObject(pThis, $0, dwHint,
+                                                RawPointer(pUnkObject),
+                                                RawPointer(pErrLog))
+      }
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IPropertyBag2.self, capacity: 1)
-
-    let hr: HRESULT = strName.withCString(encodedAs: UTF16.self) {
-      pThis.pointee.lpVtbl.pointee.LoadObject(pThis, $0, dwHint,
-                                              RawPointer(pUnkObject),
-                                              RawPointer(pErrLog))
-    }
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func Read(_ pPropBag: [PROPBAG2], _ pErrLog: IErrorLog?)
       throws -> [(VARIANT, HRESULT)] {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis = pUnk.bindMemory(to: WinSDK.IPropertyBag2.self, capacity: 1)
-
-    var pPropBag = pPropBag
-    var hrError: [HRESULT] =
-        Array<HRESULT>(repeating: S_OK, count: pPropBag.count)
-    let varValue: [VARIANT] =
-        try Array<VARIANT>(unsafeUninitializedCapacity: pPropBag.count) { pvarValue, count in
-      let hr: HRESULT = pPropBag.withUnsafeMutableBufferPointer {
-        pThis.pointee.lpVtbl.pointee.Read(pThis, ULONG($0.count), $0.baseAddress,
-                                          RawPointer(pErrLog), pvarValue.baseAddress,
-                                          &hrError)
+    return try perform(as: WinSDK.IPropertyBag2.self) { pThis in
+      var pPropBag = pPropBag
+      var hrError: [HRESULT] =
+          Array<HRESULT>(repeating: S_OK, count: pPropBag.count)
+      let varValue: [VARIANT] =
+          try Array<VARIANT>(unsafeUninitializedCapacity: pPropBag.count) { pvarValue, count in
+        let hr: HRESULT = pPropBag.withUnsafeMutableBufferPointer {
+          pThis.pointee.lpVtbl.pointee.Read(pThis, ULONG($0.count), $0.baseAddress,
+                                            RawPointer(pErrLog), pvarValue.baseAddress,
+                                            &hrError)
+        }
+        guard hr == S_OK else { throw COMError(hr: hr) }
+        count = pPropBag.count
       }
-      guard hr == S_OK else { throw COMError(hr: hr) }
-      count = pPropBag.count
+      return zip(varValue, hrError).map { ($0.0, $0.1) }
     }
-    return zip(varValue, hrError).map { ($0.0, $0.1) }
   }
 
   public func Write(_ properties: [PROPBAG2], _ values: [VARIANT]) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis = pUnk.bindMemory(to: WinSDK.IPropertyBag2.self, capacity: 1)
-
     guard properties.count == values.count else {
       throw COMError(hr: E_INVALIDARG)
     }
 
-    var properties = properties
-    var values = values
-    let hr: HRESULT = properties.withUnsafeMutableBufferPointer { pPropBag in
-      values.withUnsafeMutableBufferPointer { pvarValue in
-        pThis.pointee.lpVtbl.pointee.Write(pThis, ULONG(pPropBag.count),
-                                           pPropBag.baseAddress,
-                                           pvarValue.baseAddress)
+    return try perform(as: WinSDK.IPropertyBag2.self) { pThis in
+      var properties = properties
+      var values = values
+      let hr: HRESULT = properties.withUnsafeMutableBufferPointer { pPropBag in
+        values.withUnsafeMutableBufferPointer { pvarValue in
+          pThis.pointee.lpVtbl.pointee.Write(pThis, ULONG(pPropBag.count),
+                                            pPropBag.baseAddress,
+                                            pvarValue.baseAddress)
+        }
       }
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IPropertyChange.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IPropertyChange.swift
@@ -12,17 +12,13 @@ public class IPropertyChange: IObjectWithPropertyKey {
 
   public func ApplyToPropVariant(_ propvarIn: REFPROPVARIANT)
       throws -> PROPVARIANT {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPropertyChange.self) { pThis in
+      var propvarOut: PROPVARIANT = PROPVARIANT()
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.ApplyToPropVariant(pThis, propvarIn,
+                                                          &propvarOut)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return propvarOut
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPropertyChange.self, capacity: 1)
-
-    var propvarOut: PROPVARIANT = PROPVARIANT()
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.ApplyToPropVariant(pThis, propvarIn,
-                                                        &propvarOut)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return propvarOut
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IPropertyChangeArray.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IPropertyChangeArray.swift
@@ -11,94 +11,66 @@ public class IPropertyChangeArray: IUnknown {
   override public class var IID: IID { IID_IPropertyChangeArray }
 
   public func Append(_ ppropChange: IPropertyChange) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPropertyChangeArray.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.Append(pThis, RawPointer(ppropChange))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPropertyChangeArray.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.Append(pThis, RawPointer(ppropChange))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func AppendOrReplace(_ ppropChange: IPropertyChange) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPropertyChangeArray.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.AppendOrReplace(pThis,
+                                                      RawPointer(ppropChange))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPropertyChangeArray.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.AppendOrReplace(pThis,
-                                                     RawPointer(ppropChange))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func GetAt(_ iIndex: UINT, _ riid: inout IID)
       throws -> IUnknown {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPropertyChangeArray.self) { pThis in
+      var pv: UnsafeMutableRawPointer?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetAt(pThis, iIndex, &riid, &pv)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IUnknown(pUnk: pv)
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPropertyChangeArray.self, capacity: 1)
-
-    var pv: UnsafeMutableRawPointer?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetAt(pThis, iIndex, &riid, &pv)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IUnknown(pUnk: pv)
   }
 
   public func GetCount() throws -> UINT {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPropertyChangeArray.self) { pThis in
+      var cOperations: UINT = 0
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetCount(pThis, &cOperations)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return cOperations
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPropertyChangeArray.self, capacity: 1)
-
-    var cOperations: UINT = 0
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetCount(pThis, &cOperations)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return cOperations
   }
 
   public func InsertAt(_ iIndex: UINT, _ ppropChange: IPropertyChange) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPropertyChangeArray.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.InsertAt(pThis, iIndex,
+                                                RawPointer(ppropChange))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPropertyChangeArray.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.InsertAt(pThis, iIndex,
-                                              RawPointer(ppropChange))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func IsKeyInArray(_ key: REFPROPERTYKEY) throws -> Bool {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPropertyChangeArray.self, capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.IsKeyInArray(pThis, key)
-    switch hr {
-    case S_OK: return true
-    case E_FAIL: return false
-    default: throw COMError(hr: hr)
+    return try perform(as: WinSDK.IPropertyChangeArray.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.IsKeyInArray(pThis, key)
+      switch hr {
+      case S_OK: return true
+      case E_FAIL: return false
+      default: throw COMError(hr: hr)
+      }
     }
   }
 
   public func RemoveAt(_ iIndex: UINT) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPropertyChangeArray.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.RemoveAt(pThis, iIndex)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IPropertyChangeArray.self, capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.RemoveAt(pThis, iIndex)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IPropertyStore.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IPropertyStore.swift
@@ -11,58 +11,43 @@ public class IPropertyStore: IUnknown {
   override public class var IID: IID { IID_IPropertyStore }
 
   public func Commit() throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPropertyStore.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Commit(pThis)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IPropertyStore.self, capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Commit(pThis)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func GetAt(_ iProp: DWORD) throws -> PROPERTYKEY {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPropertyStore.self) { pThis in
+      var Key: PROPERTYKEY = PROPERTYKEY()
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetAt(pThis, iProp, &Key)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return Key
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IPropertyStore.self, capacity: 1)
-
-    var Key: PROPERTYKEY = PROPERTYKEY()
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetAt(pThis, iProp, &Key)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return Key
   }
 
   public func GetCount() throws -> DWORD {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPropertyStore.self) { pThis in
+      var cProps: DWORD = DWORD(0)
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetCount(pThis, &cProps)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return cProps
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IPropertyStore.self, capacity: 1)
-
-    var cProps: DWORD = DWORD(0)
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetCount(pThis, &cProps)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return cProps
   }
 
   public func GetValue(_ key: REFPROPERTYKEY) throws -> PROPVARIANT {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPropertyStore.self) { pThis in
+      var v: PROPVARIANT = PROPVARIANT()
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetValue(pThis, key, &v)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return v
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IPropertyStore.self, capacity: 1)
-
-    var v: PROPVARIANT = PROPVARIANT()
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetValue(pThis, key, &v)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return v
   }
 
   public func GetValue(_ key: REFPROPERTYKEY, _ propvar: REFPROPVARIANT) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IPropertyStore.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.SetValue(pThis, key, propvar)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IPropertyStore.self, capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.SetValue(pThis, key, propvar)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IRunningObjectTable.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IRunningObjectTable.swift
@@ -11,103 +11,75 @@ public class IRunningObjectTable: IUnknown {
   override public class var IID: IID { IID_IRunningObjectTable }
 
   public func EnumRunning() throws -> IEnumMoniker {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IRunningObjectTable.self) { pThis in
+      var penumMoniker: UnsafeMutablePointer<WinSDK.IEnumMoniker>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.EnumRunning(pThis, &penumMoniker)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IEnumMoniker(pUnk: penumMoniker)
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IRunningObjectTable.self, capacity: 1)
-
-    var penumMoniker: UnsafeMutablePointer<WinSDK.IEnumMoniker>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.EnumRunning(pThis, &penumMoniker)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IEnumMoniker(pUnk: penumMoniker)
   }
 
   public func GetObject(_ pmkObjectName: IMoniker) throws -> IUnknown {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IRunningObjectTable.self) { pThis in
+      var punkObject: UnsafeMutablePointer<WinSDK.IUnknown>?
+      // FIXME(compnerd) GetObject is also a free function which has a unicode and
+      // ascii version. As a result, `GetObject` is a macro which happens to
+      // expand incorrectly to `GetObjectA` here.
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetObjectA(pThis, RawPointer(pmkObjectName),
+                                                  &punkObject)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IUnknown(pUnk: punkObject)
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IRunningObjectTable.self, capacity: 1)
-
-    var punkObject: UnsafeMutablePointer<WinSDK.IUnknown>?
-    // FIXME(compnerd) GetObject is also a free function which has a unicode and
-    // ascii version. As a result, `GetObject` is a macro which happens to
-    // expand incorrectly to `GetObjectA` here.
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetObjectA(pThis, RawPointer(pmkObjectName),
-                                                &punkObject)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IUnknown(pUnk: punkObject)
   }
 
   public func GetTimeOfLastChange(_ pmkObjectName: IMoniker) throws -> FILETIME {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IRunningObjectTable.self) { pThis in
+      var filetime: FILETIME = FILETIME()
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee
+                            .GetTimeOfLastChange(pThis, RawPointer(pmkObjectName),
+                                                &filetime)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return filetime
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IRunningObjectTable.self, capacity: 1)
-
-    var filetime: FILETIME = FILETIME()
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee
-                          .GetTimeOfLastChange(pThis, RawPointer(pmkObjectName),
-                                               &filetime)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return filetime
   }
 
   public func IsRunning(_ pmkObjectName: IMoniker) throws -> Bool {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IRunningObjectTable.self) { pThis in
+      return pThis.pointee.lpVtbl.pointee.IsRunning(pThis,
+                                                    RawPointer(pmkObjectName)) == S_OK
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IRunningObjectTable.self, capacity: 1)
-
-    return pThis.pointee.lpVtbl.pointee.IsRunning(pThis,
-                                                  RawPointer(pmkObjectName)) == S_OK
   }
 
   public func NoteChangeTime(_ dwRegister: DWORD) throws -> FILETIME {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IRunningObjectTable.self) { pThis in
+      var filetime: FILETIME = FILETIME()
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.NoteChangeTime(pThis, dwRegister, &filetime)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return filetime
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IRunningObjectTable.self, capacity: 1)
-
-    var filetime: FILETIME = FILETIME()
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.NoteChangeTime(pThis, dwRegister, &filetime)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return filetime
   }
 
   public func Register(_ grfFlags: DWORD, _ punkObject: IUnknown,
                        _ pmkObjectName: IMoniker) throws -> DWORD {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IRunningObjectTable.self) { pThis in
+      var dwRegister: DWORD = 0
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.Register(pThis, grfFlags, punkObject.pUnk,
+                                                RawPointer(pmkObjectName),
+                                                &dwRegister)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return dwRegister
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IRunningObjectTable.self, capacity: 1)
-
-    var dwRegister: DWORD = 0
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.Register(pThis, grfFlags, punkObject.pUnk,
-                                              RawPointer(pmkObjectName),
-                                              &dwRegister)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return dwRegister
   }
 
   public func Revoke(_ dwRegister: DWORD) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IRunningObjectTable.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.Revoke(pThis, dwRegister)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IRunningObjectTable.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.Revoke(pThis, dwRegister)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/ISensor.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ISensor.swift
@@ -11,199 +11,154 @@ public class ISensor: IUnknown {
   override public class var IID: IID { IID_ISensor }
 
   public func GetCategory() throws -> SENSOR_CATEGORY_ID {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ISensor.self) { pThis in
+      var SensorCategory: SENSOR_CATEGORY_ID = SENSOR_CATEGORY_ID()
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetCategory(pThis, &SensorCategory)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return SensorCategory
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ISensor.self, capacity: 1)
-
-    var SensorCategory: SENSOR_CATEGORY_ID = SENSOR_CATEGORY_ID()
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetCategory(pThis, &SensorCategory)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return SensorCategory
   }
 
   public func GetData() throws -> ISensorDataReport {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ISensor.self) { pThis in
+      var pDataReport: UnsafeMutablePointer<WinSDK.ISensorDataReport>?
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetData(pThis, &pDataReport)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return ISensorDataReport(pUnk: pDataReport)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ISensor.self, capacity: 1)
-
-    var pDataReport: UnsafeMutablePointer<WinSDK.ISensorDataReport>?
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetData(pThis, &pDataReport)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return ISensorDataReport(pUnk: pDataReport)
   }
 
   public func GetEventInterest() throws -> [GUID] {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ISensor.self) { pThis in
+      var pValues: UnsafeMutablePointer<GUID>?
+      var Count: ULONG = ULONG()
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetEventInterest(pThis, &pValues, &Count)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return Array(UnsafeBufferPointer<GUID>(start: pValues, count: Int(Count)))
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ISensor.self, capacity: 1)
-
-    var pValues: UnsafeMutablePointer<GUID>?
-    var Count: ULONG = ULONG()
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetEventInterest(pThis, &pValues, &Count)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return Array(UnsafeBufferPointer<GUID>(start: pValues, count: Int(Count)))
   }
 
   public func GetFriendlyName() throws -> String {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ISensor.self) { pThis in
+      var FriendlyName: BSTR?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetFriendlyName(pThis, &FriendlyName)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      defer { SysFreeString(FriendlyName) }
+      return FriendlyName == nil ? "" : String(from: FriendlyName!)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ISensor.self, capacity: 1)
-
-    var FriendlyName: BSTR?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetFriendlyName(pThis, &FriendlyName)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    defer { SysFreeString(FriendlyName) }
-    return FriendlyName == nil ? "" : String(from: FriendlyName!)
   }
 
   public func GetID() throws -> SENSOR_ID {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ISensor.self) { pThis in
+      var ID: SENSOR_ID = SENSOR_ID()
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetID(pThis, &ID)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return ID
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ISensor.self, capacity: 1)
-
-    var ID: SENSOR_ID = SENSOR_ID()
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetID(pThis, &ID)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return ID
   }
 
   public func GetProperties(_ Keys: IPortableDeviceKeyCollection?)
       throws -> IPortableDeviceValues {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ISensor.self) { pThis in
+      var pProperties: UnsafeMutablePointer<WinSDK.IPortableDeviceValues>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetProperties(pThis, RawPointer(Keys),
+                                                    &pProperties)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IPortableDeviceValues(pUnk: pProperties)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ISensor.self, capacity: 1)
-
-    var pProperties: UnsafeMutablePointer<WinSDK.IPortableDeviceValues>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetProperties(pThis, RawPointer(Keys),
-                                                   &pProperties)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IPortableDeviceValues(pUnk: pProperties)
   }
 
   public func GetProperty(_ key: REFPROPERTYKEY) throws -> PROPVARIANT {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ISensor.self) { pThis in
+      var Property: PROPVARIANT = PROPVARIANT()
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetProperty(pThis, key, &Property)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return Property
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ISensor.self, capacity: 1)
-
-    var Property: PROPVARIANT = PROPVARIANT()
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetProperty(pThis, key, &Property)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return Property
   }
 
   public func GetState() throws -> SensorState {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ISensor.self) { pThis in
+      var State: SensorState = SensorState(0)
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetState(pThis, &State)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return State
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ISensor.self, capacity: 1)
-
-    var State: SensorState = SensorState(0)
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetState(pThis, &State)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return State
   }
 
   public func GetSupportedDataFields() throws -> IPortableDeviceKeyCollection {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ISensor.self) { pThis in
+      var pDataFields: UnsafeMutablePointer<WinSDK.IPortableDeviceKeyCollection>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetSupportedDataFields(pThis, &pDataFields)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IPortableDeviceKeyCollection(pUnk: pDataFields)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ISensor.self, capacity: 1)
-
-    var pDataFields: UnsafeMutablePointer<WinSDK.IPortableDeviceKeyCollection>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetSupportedDataFields(pThis, &pDataFields)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IPortableDeviceKeyCollection(pUnk: pDataFields)
   }
 
   public func GetType() throws -> SENSOR_TYPE_ID {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ISensor.self) { pThis in
+      var SensorType: SENSOR_TYPE_ID = SENSOR_TYPE_ID()
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetType(pThis, &SensorType)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return SensorType
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ISensor.self, capacity: 1)
-
-    var SensorType: SENSOR_TYPE_ID = SENSOR_TYPE_ID()
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetType(pThis, &SensorType)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return SensorType
   }
 
   public func SetEventInterest(_ Values: [GUID]) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ISensor.self) { pThis in
+      var Values = Values
+      let hr: HRESULT = Values.withUnsafeMutableBufferPointer {
+        pThis.pointee.lpVtbl.pointee.SetEventInterest(pThis, $0.baseAddress,
+                                                      ULONG($0.count))
+      }
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ISensor.self, capacity: 1)
-
-    var Values = Values
-    let hr: HRESULT = Values.withUnsafeMutableBufferPointer {
-      pThis.pointee.lpVtbl.pointee.SetEventInterest(pThis, $0.baseAddress,
-                                                    ULONG($0.count))
-    }
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetEventSink(_ pEvents: ISensorEvents?) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ISensor.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.SetEventSink(pThis, RawPointer(pEvents))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ISensor.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetEventSink(pThis, RawPointer(pEvents))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetProperties(_ pProperties: IPortableDeviceValues)
       throws -> IPortableDeviceValues {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ISensor.self) { pThis in
+      var pResults: UnsafeMutablePointer<WinSDK.IPortableDeviceValues>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.SetProperties(pThis, RawPointer(pProperties),
+                                                    &pResults)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IPortableDeviceValues(pUnk: pResults)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ISensor.self, capacity: 1)
-
-    var pResults: UnsafeMutablePointer<WinSDK.IPortableDeviceValues>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetProperties(pThis, RawPointer(pProperties),
-                                                   &pResults)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IPortableDeviceValues(pUnk: pResults)
   }
 
   public func SupportsDataField(_ key: REFPROPERTYKEY) throws -> Bool {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ISensor.self) { pThis in
+      var IsSupported: VARIANT_BOOL = VARIANT_BOOL()
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.SupportsDataField(pThis, key, &IsSupported)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IsSupported == VARIANT_TRUE
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ISensor.self, capacity: 1)
-
-    var IsSupported: VARIANT_BOOL = VARIANT_BOOL()
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SupportsDataField(pThis, key, &IsSupported)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IsSupported == VARIANT_TRUE
   }
 
   public func SupportsEvent(_ eventGuid: REFGUID) throws -> Bool {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ISensor.self) { pThis in
+      var IsSupported: VARIANT_BOOL = VARIANT_BOOL()
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.SupportsEvent(pThis, eventGuid,
+                                                    &IsSupported)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IsSupported == VARIANT_TRUE
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ISensor.self, capacity: 1)
-
-    var IsSupported: VARIANT_BOOL = VARIANT_BOOL()
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SupportsEvent(pThis, eventGuid,
-                                                   &IsSupported)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IsSupported == VARIANT_TRUE
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/ISensorCollection.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ISensorCollection.swift
@@ -11,69 +11,51 @@ public class ISensorCollection: IUnknown {
   override public class var IID: IID { IID_ISensorCollection }
 
   public func Add(_ pSensor: ISensor) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ISensorCollection.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.Add(pThis, RawPointer(pSensor))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ISensorCollection.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.Add(pThis, RawPointer(pSensor))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func Clear() throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ISensorCollection.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Clear(pThis)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ISensorCollection.self, capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Clear(pThis)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func GetAt(_ ulIndex: ULONG) throws -> ISensor {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ISensorCollection.self) { pThis in
+      var pSensor: UnsafeMutablePointer<WinSDK.ISensor>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetAt(pThis, ulIndex, &pSensor)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return ISensor(pUnk: pSensor)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ISensorCollection.self, capacity: 1)
-
-    var pSensor: UnsafeMutablePointer<WinSDK.ISensor>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetAt(pThis, ulIndex, &pSensor)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return ISensor(pUnk: pSensor)
   }
 
   public func GetCount() throws -> ULONG {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ISensorCollection.self) { pThis in
+      var Count: ULONG = ULONG(0)
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetCount(pThis, &Count)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return Count
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ISensorCollection.self, capacity: 1)
-
-    var Count: ULONG = ULONG(0)
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetCount(pThis, &Count)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return Count
   }
 
   public func Remove(_ pSensor: ISensor) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ISensorCollection.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.Remove(pThis, RawPointer(pSensor))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ISensorCollection.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.Remove(pThis, RawPointer(pSensor))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func RemoveByID(_ sensorID: REFSENSOR_ID) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ISensorCollection.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.RemoveByID(pThis, sensorID)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ISensorCollection.self, capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.RemoveByID(pThis, sensorID)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/ISensorDataReport.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ISensorDataReport.swift
@@ -11,43 +11,34 @@ public class ISensorDataReport: IUnknown {
   override public class var IID: IID { IID_ISensorDataReport }
 
   public func GetSensorValue(_ pKey: REFPROPERTYKEY) throws -> PROPVARIANT {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ISensorDataReport.self) { pThis in
+      var Value: PROPVARIANT = PROPVARIANT()
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetSensorValue(pThis, pKey, &Value)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return Value
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ISensorDataReport.self, capacity: 1)
-
-    var Value: PROPVARIANT = PROPVARIANT()
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetSensorValue(pThis, pKey, &Value)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return Value
   }
 
   public func GetSensorValues(_ pKeys: IPortableDeviceKeyCollection?)
       throws -> IPortableDeviceValues {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ISensorDataReport.self) { pThis in
+      var pValues: UnsafeMutablePointer<WinSDK.IPortableDeviceValues>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetSensorValues(pThis, RawPointer(pKeys),
+                                                       &pValues)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IPortableDeviceValues(pUnk: pValues)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ISensorDataReport.self, capacity: 1)
-
-    var pValues: UnsafeMutablePointer<WinSDK.IPortableDeviceValues>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetSensorValues(pThis, RawPointer(pKeys),
-                                                     &pValues)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IPortableDeviceValues(pUnk: pValues)
   }
 
   public func GetTimestamp() throws -> SYSTEMTIME {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ISensorDataReport.self) { pThis in
+      var TimeStamp: SYSTEMTIME = SYSTEMTIME()
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetTimestamp(pThis, &TimeStamp)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return TimeStamp
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ISensorDataReport.self, capacity: 1)
-
-    var TimeStamp: SYSTEMTIME = SYSTEMTIME()
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetTimestamp(pThis, &TimeStamp)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return TimeStamp
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/ISensorManager.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ISensorManager.swift
@@ -11,72 +11,57 @@ public class ISensorManager: IUnknown {
   override public class var IID: IID { IID_ISensorManager }
 
   public func GetSensorByID(_ sensorID: REFSENSOR_ID) throws -> ISensor {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ISensorManager.self) { pThis in
+      var pSensor: UnsafeMutablePointer<WinSDK.ISensor>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetSensorByID(pThis, sensorID, &pSensor)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return ISensor(pUnk: pSensor)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ISensorManager.self, capacity: 1)
-
-    var pSensor: UnsafeMutablePointer<WinSDK.ISensor>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetSensorByID(pThis, sensorID, &pSensor)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return ISensor(pUnk: pSensor)
   }
 
   public func GetSensorsByCategory(_ sensorCategory: REFSENSOR_CATEGORY_ID)
       throws -> ISensorCollection {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ISensorManager.self) { pThis in
+      var pSensorsFound: UnsafeMutablePointer<WinSDK.ISensorCollection>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetSensorsByCategory(pThis, sensorCategory,
+                                                            &pSensorsFound)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return ISensorCollection(pUnk: pSensorsFound)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ISensorManager.self, capacity: 1)
-
-    var pSensorsFound: UnsafeMutablePointer<WinSDK.ISensorCollection>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetSensorsByCategory(pThis, sensorCategory,
-                                                          &pSensorsFound)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return ISensorCollection(pUnk: pSensorsFound)
   }
 
   public func GetSensorsByType(_ sensorType: REFSENSOR_TYPE_ID)
       throws -> ISensorCollection {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ISensorManager.self) { pThis in
+      var pSensorsFound: UnsafeMutablePointer<WinSDK.ISensorCollection>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetSensorsByType(pThis, sensorType,
+                                                        &pSensorsFound)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return ISensorCollection(pUnk: pSensorsFound)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ISensorManager.self, capacity: 1)
-
-    var pSensorsFound: UnsafeMutablePointer<WinSDK.ISensorCollection>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetSensorsByType(pThis, sensorType,
-                                                      &pSensorsFound)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return ISensorCollection(pUnk: pSensorsFound)
   }
 
   public func RequestPermissions(_ hParent: HWND?,
                                  _ pSensors: ISensorCollection?, _ fModal: Bool)
       throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ISensorManager.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.RequestPermissions(pThis, hParent,
+                                                          RawPointer(pSensors),
+                                                          WindowsBool(fModal))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ISensorManager.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.RequestPermissions(pThis, hParent,
-                                                        RawPointer(pSensors),
-                                                        WindowsBool(fModal))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetEventSink(_ pEvents: ISensorManagerEvents?) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ISensorManager.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.SetEventSink(pThis, RawPointer(pEvents))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ISensorManager.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetEventSink(pThis, RawPointer(pEvents))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }
 

--- a/Sources/SwiftCOM/Interfaces/Human/IShellItem.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IShellItem.swift
@@ -12,70 +12,55 @@ public class IShellItem: IUnknown {
 
   public func BindToHandler(_ pbc: IBindCtx, _ bhid: inout GUID,
                             _ riid: inout IID) throws -> IUnknown {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IShellItem.self) { pThis in
+      var pv: UnsafeMutableRawPointer?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.BindToHandler(pThis, RawPointer(pbc),
+                                                    &bhid, &riid, &pv)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IUnknown(pUnk: pv)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IShellItem.self, capacity: 1)
-
-    var pv: UnsafeMutableRawPointer?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.BindToHandler(pThis, RawPointer(pbc),
-                                                   &bhid, &riid, &pv)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IUnknown(pUnk: pv)
   }
 
   public func Compare(_ psi: IShellItem, _ hint: SICHINTF) throws -> CInt {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IShellItem.self) { pThis in
+      var iOrder: CInt = 0
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.Compare(pThis, RawPointer(psi), hint,
+                                              &iOrder)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return iOrder
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IShellItem.self, capacity: 1)
-
-    var iOrder: CInt = 0
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.Compare(pThis, RawPointer(psi), hint,
-                                             &iOrder)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return iOrder
   }
 
   public func GetAttributes(_ sfgaoMask: SFGAOF) throws -> SFGAOF {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IShellItem.self) { pThis in
+      var sfgaoAttribs: SFGAOF = SFGAOF()
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetAttributes(pThis, sfgaoMask,
+                                                    &sfgaoAttribs)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return sfgaoAttribs
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IShellItem.self, capacity: 1)
-
-    var sfgaoAttribs: SFGAOF = SFGAOF()
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetAttributes(pThis, sfgaoMask,
-                                                   &sfgaoAttribs)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return sfgaoAttribs
   }
 
   public func GetDisplayName(_ sigdnName: SIGDN) throws -> String {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IShellItem.self) { pThis in
+      var pszName: LPWSTR?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetDisplayName(pThis, sigdnName, &pszName)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      defer { CoTaskMemFree(pszName) }
+      return String(decodingCString: pszName!, as: UTF16.self)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IShellItem.self, capacity: 1)
-
-    var pszName: LPWSTR?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetDisplayName(pThis, sigdnName, &pszName)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    defer { CoTaskMemFree(pszName) }
-    return String(decodingCString: pszName!, as: UTF16.self)
   }
 
   public func GetParent() throws -> IShellItem {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IShellItem.self) { pThis in
+      var psi: UnsafeMutablePointer<WinSDK.IShellItem>?
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetParent(pThis, &psi)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IShellItem(pUnk: psi)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IShellItem.self, capacity: 1)
-
-    var psi: UnsafeMutablePointer<WinSDK.IShellItem>?
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetParent(pThis, &psi)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IShellItem(pUnk: psi)
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IStream.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IStream.swift
@@ -11,113 +11,86 @@ public class IStream: IUnknown {
   override public class var IID: IID { IID_IStream }
 
   public func Clone() throws -> IStream {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IStream.self) { pThis in
+      var pstm: UnsafeMutablePointer<WinSDK.IStream>?
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Clone(pThis, &pstm)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IStream(pUnk: pstm)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IStream.self, capacity: 1)
-
-    var pstm: UnsafeMutablePointer<WinSDK.IStream>?
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Clone(pThis, &pstm)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IStream(pUnk: pstm)
   }
 
   public func Commit(_ grfCommitFlags: DWORD) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IStream.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Commit(pThis, grfCommitFlags)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IStream.self, capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Commit(pThis, grfCommitFlags)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func CopyTo(_ pstm: IStream, _ cb: ULARGE_INTEGER)
       throws -> (ULARGE_INTEGER, ULARGE_INTEGER) {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IStream.self) { pThis in
+      var cbRead: ULARGE_INTEGER = ULARGE_INTEGER()
+      var cbWritten: ULARGE_INTEGER = ULARGE_INTEGER()
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.CopyTo(pThis, RawPointer(pstm), cb,
+                                              &cbRead, &cbWritten)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return (cbRead, cbWritten)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IStream.self, capacity: 1)
-
-    var cbRead: ULARGE_INTEGER = ULARGE_INTEGER()
-    var cbWritten: ULARGE_INTEGER = ULARGE_INTEGER()
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.CopyTo(pThis, RawPointer(pstm), cb,
-                                            &cbRead, &cbWritten)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return (cbRead, cbWritten)
   }
 
   public func LockRegion(_ libOffset: ULARGE_INTEGER, _ cb: ULARGE_INTEGER,
                          _ dwLockType: DWORD) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IStream.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.LockRegion(pThis, libOffset, cb, dwLockType)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IStream.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.LockRegion(pThis, libOffset, cb, dwLockType)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func Revert() throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IStream.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Revert(pThis)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IStream.self, capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Revert(pThis)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func Seek(_ dlibMove: LARGE_INTEGER, _ dwOrigin: DWORD)
       throws -> ULARGE_INTEGER {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IStream.self) { pThis in
+      var libNewPosition: ULARGE_INTEGER = ULARGE_INTEGER()
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.Seek(pThis, dlibMove, dwOrigin,
+                                            &libNewPosition)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return libNewPosition
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IStream.self, capacity: 1)
-
-    var libNewPosition: ULARGE_INTEGER = ULARGE_INTEGER()
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.Seek(pThis, dlibMove, dwOrigin,
-                                          &libNewPosition)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return libNewPosition
   }
 
   public func SetSize(_ libNewSize: ULARGE_INTEGER) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IStream.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.SetSize(pThis, libNewSize)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IStream.self, capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.SetSize(pThis, libNewSize)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func Stat(_ grfStatFlag: DWORD) throws -> STATSTG {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IStream.self) { pThis in
+      var statstg: STATSTG = STATSTG()
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.Stat(pThis, &statstg, grfStatFlag)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return statstg
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IStream.self, capacity: 1)
-
-    var statstg: STATSTG = STATSTG()
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.Stat(pThis, &statstg, grfStatFlag)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return statstg
   }
 
   public func UnlockRegion(_ libOffset: ULARGE_INTEGER, _ cb: ULARGE_INTEGER,
                            _ dwLockType: DWORD) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IStream.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.UnlockRegion(pThis, libOffset, cb,
+                                                    dwLockType)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IStream.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.UnlockRegion(pThis, libOffset, cb,
-                                                  dwLockType)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmap.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmap.swift
@@ -11,39 +11,30 @@ public class IWICBitmap: IWICBitmapSource {
   override public class var IID: IID { IID_IWICBitmap }
 
   public func Lock(_ rcLock: WICRect, _ flags: DWORD) throws -> IWICBitmapLock {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmap.self) { pThis in
+      var rcLock = rcLock
+      var pILock: UnsafeMutablePointer<WinSDK.IWICBitmapLock>?
+      let hr: HRESULT = withUnsafePointer(to: &rcLock) {
+        pThis.pointee.lpVtbl.pointee.Lock(pThis, $0, flags, &pILock)
+      }
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICBitmapLock(pUnk: pILock)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmap.self, capacity: 1)
-
-    var rcLock = rcLock
-    var pILock: UnsafeMutablePointer<WinSDK.IWICBitmapLock>?
-    let hr: HRESULT = withUnsafePointer(to: &rcLock) {
-      pThis.pointee.lpVtbl.pointee.Lock(pThis, $0, flags, &pILock)
-    }
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICBitmapLock(pUnk: pILock)
   }
 
   public func SetPalette(_ pIPalette: IWICPalette) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmap.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.SetPalette(pThis, RawPointer(pIPalette))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmap.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetPalette(pThis, RawPointer(pIPalette))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetResolution(_ dpiX: Double, _ dpiY: Double) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmap.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.SetResolution(pThis, dpiX, dpiY)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmap.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetResolution(pThis, dpiX, dpiY)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapClipper.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapClipper.swift
@@ -11,15 +11,12 @@ public class IWICBitmapClipper: IWICBitmapSource {
   override public class var IID: IID { IID_IWICBitmapClipper }
 
   public func Initialize(_ pISource: IWICBitmapSource, _ rc: WICRect) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapClipper.self) { pThis in
+      var rc = rc
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.Initialize(pThis, RawPointer(pISource),
+                                                  &rc)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapClipper.self, capacity: 1)
-
-    var rc = rc
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.Initialize(pThis, RawPointer(pISource),
-                                                &rc)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapCodecInfo.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapCodecInfo.swift
@@ -11,224 +11,188 @@ public class IWICBitmapCodecInfo: IWICComponentInfo {
   override public class var IID: IID { IID_IWICBitmapCodecInfo }
 
   public func DoesSupportAnimation() throws -> Bool {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapCodecInfo.self) { pThis in
+      var fSupportAnimation: WindowsBool = false
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.DoesSupportAnimation(pThis,
+                                                            &fSupportAnimation)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return fSupportAnimation == true
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapCodecInfo.self, capacity: 1)
-
-    var fSupportAnimation: WindowsBool = false
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.DoesSupportAnimation(pThis,
-                                                          &fSupportAnimation)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return fSupportAnimation == true
   }
 
   public func DoesSupportChromakey() throws -> Bool {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapCodecInfo.self) { pThis in
+      var fSupportChromakey: WindowsBool = false
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.DoesSupportChromakey(pThis,
+                                                            &fSupportChromakey)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return fSupportChromakey == true
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapCodecInfo.self, capacity: 1)
-
-    var fSupportChromakey: WindowsBool = false
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.DoesSupportChromakey(pThis,
-                                                          &fSupportChromakey)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return fSupportChromakey == true
   }
 
   public func DoesSupportLossless() throws -> Bool {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapCodecInfo.self) { pThis in
+      var fSupportLossless: WindowsBool = false
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.DoesSupportLossless(pThis,
+                                                          &fSupportLossless)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return fSupportLossless == true
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapCodecInfo.self, capacity: 1)
-
-    var fSupportLossless: WindowsBool = false
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.DoesSupportLossless(pThis,
-                                                         &fSupportLossless)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return fSupportLossless == true
   }
 
   public func DoesSupportMultiframe() throws -> Bool {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapCodecInfo.self) { pThis in
+      var fSupportMultiframe: WindowsBool = false
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.DoesSupportMultiframe(pThis,
+                                                            &fSupportMultiframe)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return fSupportMultiframe == true
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapCodecInfo.self, capacity: 1)
-
-    var fSupportMultiframe: WindowsBool = false
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.DoesSupportMultiframe(pThis,
-                                                           &fSupportMultiframe)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return fSupportMultiframe == true
   }
 
   public func GetColorManagementVersion() throws -> String {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapCodecInfo.self, capacity: 1)
-
-    var cchActual: UINT = UINT(0)
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetColorManagementVersion(pThis, 0, nil,
-                                                               &cchActual)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-
-    let buffer: [WCHAR] =
-        try Array<WCHAR>(unsafeUninitializedCapacity: Int(cchActual)) {
+    return try perform(as: WinSDK.IWICBitmapCodecInfo.self) { pThis in
+      var cchActual: UINT = UINT(0)
       let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetColorManagementVersion(pThis,
-                                                                 UINT($0.count),
-                                                                 $0.baseAddress,
-                                                                 &cchActual)
+          pThis.pointee.lpVtbl.pointee.GetColorManagementVersion(pThis, 0, nil,
+                                                                &cchActual)
       guard hr == S_OK else { throw COMError(hr: hr) }
-      $1 = Int(cchActual)
+
+      let buffer: [WCHAR] =
+          try Array<WCHAR>(unsafeUninitializedCapacity: Int(cchActual)) {
+        let hr: HRESULT =
+            pThis.pointee.lpVtbl.pointee.GetColorManagementVersion(pThis,
+                                                                  UINT($0.count),
+                                                                  $0.baseAddress,
+                                                                  &cchActual)
+        guard hr == S_OK else { throw COMError(hr: hr) }
+        $1 = Int(cchActual)
+      }
+      return String(decoding: buffer, as: UTF16.self)
     }
-    return String(decoding: buffer, as: UTF16.self)
   }
 
   public func GetContainerFormat() throws -> GUID {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapCodecInfo.self) { pThis in
+      var guidContainerFromat: GUID = GUID()
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetContainerFormat(pThis,
+                                                          &guidContainerFromat)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return guidContainerFromat
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapCodecInfo.self, capacity: 1)
-
-    var guidContainerFromat: GUID = GUID()
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetContainerFormat(pThis,
-                                                        &guidContainerFromat)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return guidContainerFromat
   }
 
   public func GetDeviceManufacturer() throws -> String {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapCodecInfo.self, capacity: 1)
-
-    var cchActual: UINT = UINT(0)
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetDeviceManufacturer(pThis, 0, nil,
-                                                           &cchActual)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-
-    let buffer: [WCHAR] =
-        try Array<WCHAR>(unsafeUninitializedCapacity: Int(cchActual)) {
+    return try perform(as: WinSDK.IWICBitmapCodecInfo.self) { pThis in
+      var cchActual: UINT = UINT(0)
       let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetDeviceManufacturer(pThis,
-                                                             UINT($0.count),
-                                                             $0.baseAddress,
-                                                             &cchActual)
+          pThis.pointee.lpVtbl.pointee.GetDeviceManufacturer(pThis, 0, nil,
+                                                            &cchActual)
       guard hr == S_OK else { throw COMError(hr: hr) }
-      $1 = Int(cchActual)
+
+      let buffer: [WCHAR] =
+          try Array<WCHAR>(unsafeUninitializedCapacity: Int(cchActual)) {
+        let hr: HRESULT =
+            pThis.pointee.lpVtbl.pointee.GetDeviceManufacturer(pThis,
+                                                              UINT($0.count),
+                                                              $0.baseAddress,
+                                                              &cchActual)
+        guard hr == S_OK else { throw COMError(hr: hr) }
+        $1 = Int(cchActual)
+      }
+      return String(decoding: buffer, as: UTF16.self)
     }
-    return String(decoding: buffer, as: UTF16.self)
   }
 
   public func GetDeviceModels() throws -> String {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapCodecInfo.self, capacity: 1)
-
-    var cchActual: UINT = UINT(0)
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetDeviceModels(pThis, 0, nil, &cchActual)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-
-    let buffer: [WCHAR] =
-        try Array<WCHAR>(unsafeUninitializedCapacity: Int(cchActual)) {
+    return try perform(as: WinSDK.IWICBitmapCodecInfo.self) { pThis in
+      var cchActual: UINT = UINT(0)
       let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetDeviceModels(pThis, UINT($0.count),
-                                                       $0.baseAddress,
-                                                       &cchActual)
+          pThis.pointee.lpVtbl.pointee.GetDeviceModels(pThis, 0, nil, &cchActual)
       guard hr == S_OK else { throw COMError(hr: hr) }
-      $1 = Int(cchActual)
+
+      let buffer: [WCHAR] =
+          try Array<WCHAR>(unsafeUninitializedCapacity: Int(cchActual)) {
+        let hr: HRESULT =
+            pThis.pointee.lpVtbl.pointee.GetDeviceModels(pThis, UINT($0.count),
+                                                        $0.baseAddress,
+                                                        &cchActual)
+        guard hr == S_OK else { throw COMError(hr: hr) }
+        $1 = Int(cchActual)
+      }
+      return String(decoding: buffer, as: UTF16.self)
     }
-    return String(decoding: buffer, as: UTF16.self)
   }
 
   public func GetFileExtensions() throws -> String {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapCodecInfo.self, capacity: 1)
-
-    var cchActual: UINT = UINT(0)
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetFileExtensions(pThis, 0, nil, &cchActual)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-
-    let buffer: [WCHAR] =
-        try Array<WCHAR>(unsafeUninitializedCapacity: Int(cchActual)) {
+    return try perform(as: WinSDK.IWICBitmapCodecInfo.self) { pThis in
+      var cchActual: UINT = UINT(0)
       let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetFileExtensions(pThis, UINT($0.count),
-                                                         $0.baseAddress,
-                                                         &cchActual)
+          pThis.pointee.lpVtbl.pointee.GetFileExtensions(pThis, 0, nil, &cchActual)
       guard hr == S_OK else { throw COMError(hr: hr) }
-      $1 = Int(cchActual)
+
+      let buffer: [WCHAR] =
+          try Array<WCHAR>(unsafeUninitializedCapacity: Int(cchActual)) {
+        let hr: HRESULT =
+            pThis.pointee.lpVtbl.pointee.GetFileExtensions(pThis, UINT($0.count),
+                                                          $0.baseAddress,
+                                                          &cchActual)
+        guard hr == S_OK else { throw COMError(hr: hr) }
+        $1 = Int(cchActual)
+      }
+      return String(decoding: buffer, as: UTF16.self)
     }
-    return String(decoding: buffer, as: UTF16.self)
   }
 
   public func GetMimeTypes() throws -> String {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapCodecInfo.self, capacity: 1)
-
-    var cchActual: UINT = UINT(0)
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetMimeTypes(pThis, 0, nil, &cchActual)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-
-    let buffer: [WCHAR] =
-        try Array<WCHAR>(unsafeUninitializedCapacity: Int(cchActual)) {
+    return try perform(as: WinSDK.IWICBitmapCodecInfo.self) { pThis in
+      var cchActual: UINT = UINT(0)
       let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetMimeTypes(pThis, UINT($0.count),
-                                                    $0.baseAddress, &cchActual)
+          pThis.pointee.lpVtbl.pointee.GetMimeTypes(pThis, 0, nil, &cchActual)
       guard hr == S_OK else { throw COMError(hr: hr) }
-      $1 = Int(cchActual)
+
+      let buffer: [WCHAR] =
+          try Array<WCHAR>(unsafeUninitializedCapacity: Int(cchActual)) {
+        let hr: HRESULT =
+            pThis.pointee.lpVtbl.pointee.GetMimeTypes(pThis, UINT($0.count),
+                                                      $0.baseAddress, &cchActual)
+        guard hr == S_OK else { throw COMError(hr: hr) }
+        $1 = Int(cchActual)
+      }
+      return String(decoding: buffer, as: UTF16.self)
     }
-    return String(decoding: buffer, as: UTF16.self)
   }
 
   public func GetPixelFormats() throws -> [GUID] {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapCodecInfo.self, capacity: 1)
-
-    var cActual: UINT = UINT(0)
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetPixelFormats(pThis, 0, nil, &cActual)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-
-    return try Array<GUID>(unsafeUninitializedCapacity: Int(cActual)) {
+    return try perform(as: WinSDK.IWICBitmapCodecInfo.self) { pThis in
+      var cActual: UINT = UINT(0)
       let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetPixelFormats(pThis, UINT($0.count),
-                                                       $0.baseAddress, &cActual)
+          pThis.pointee.lpVtbl.pointee.GetPixelFormats(pThis, 0, nil, &cActual)
       guard hr == S_OK else { throw COMError(hr: hr) }
-      $1 = Int(cActual)
+
+      return try Array<GUID>(unsafeUninitializedCapacity: Int(cActual)) {
+        let hr: HRESULT =
+            pThis.pointee.lpVtbl.pointee.GetPixelFormats(pThis, UINT($0.count),
+                                                        $0.baseAddress, &cActual)
+        guard hr == S_OK else { throw COMError(hr: hr) }
+        $1 = Int(cActual)
+      }
     }
   }
 
   public func MatchesMimeType(_ szMimeType: String) throws -> Bool {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapCodecInfo.self) { pThis in
+      var fMatches: WindowsBool = false
+      let hr: HRESULT = szMimeType.withCString(encodedAs: UTF16.self) {
+        pThis.pointee.lpVtbl.pointee.MatchesMimeType(pThis, $0, &fMatches)
+      }
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return fMatches == true
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapCodecInfo.self, capacity: 1)
-
-    var fMatches: WindowsBool = false
-    let hr: HRESULT = szMimeType.withCString(encodedAs: UTF16.self) {
-      pThis.pointee.lpVtbl.pointee.MatchesMimeType(pThis, $0, &fMatches)
-    }
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return fMatches == true
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapDecoder.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapDecoder.swift
@@ -11,164 +11,131 @@ public class IWICBitmapDecoder: IUnknown {
   override public class var IID: IID { IID_IWICBitmapDecoder }
 
   public func CopyPalette(_ pIPalette: IWICPalette) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapDecoder.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.CopyPalette(pThis, RawPointer(pIPalette))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapDecoder.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.CopyPalette(pThis, RawPointer(pIPalette))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func GetColorContexts() throws -> [IWICColorContext] {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapDecoder.self, capacity: 1)
-
-    var cActualCount: UINT = UINT(0)
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetColorContexts(pThis, 0, nil,
-                                                      &cActualCount)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-
-    let contexts: [UnsafeMutablePointer<WinSDK.IWICColorContext>?] =
-        try .init(unsafeUninitializedCapacity: Int(cActualCount)) {
+    return try perform(as: WinSDK.IWICBitmapDecoder.self) { pThis in
+      var cActualCount: UINT = UINT(0)
       let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetColorContexts(pThis, cActualCount,
-                                                        $0.baseAddress,
+          pThis.pointee.lpVtbl.pointee.GetColorContexts(pThis, 0, nil,
                                                         &cActualCount)
       guard hr == S_OK else { throw COMError(hr: hr) }
-      $1 = Int(cActualCount)
-    }
 
-    return contexts.map { IWICColorContext(pUnk: $0) }
+      let contexts: [UnsafeMutablePointer<WinSDK.IWICColorContext>?] =
+          try .init(unsafeUninitializedCapacity: Int(cActualCount)) {
+        let hr: HRESULT =
+            pThis.pointee.lpVtbl.pointee.GetColorContexts(pThis, cActualCount,
+                                                          $0.baseAddress,
+                                                          &cActualCount)
+        guard hr == S_OK else { throw COMError(hr: hr) }
+        $1 = Int(cActualCount)
+      }
+
+      return contexts.map { IWICColorContext(pUnk: $0) }
+    }
   }
 
   public func GetContainerFormat() throws -> GUID {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapDecoder.self) { pThis in
+      var guidContainerFormat: GUID = GUID()
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetContainerFormat(pThis,
+                                                          &guidContainerFormat)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+
+      return guidContainerFormat
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapDecoder.self, capacity: 1)
-
-    var guidContainerFormat: GUID = GUID()
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetContainerFormat(pThis,
-                                                        &guidContainerFormat)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-
-    return guidContainerFormat
   }
 
   public func GetDecoderInfo() throws -> IWICBitmapDecoderInfo {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapDecoder.self) { pThis in
+      var pIDecoderInfo: UnsafeMutablePointer<WinSDK.IWICBitmapDecoderInfo>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetDecoderInfo(pThis, &pIDecoderInfo)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+
+      return IWICBitmapDecoderInfo(pUnk: pIDecoderInfo)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapDecoder.self, capacity: 1)
-
-    var pIDecoderInfo: UnsafeMutablePointer<WinSDK.IWICBitmapDecoderInfo>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetDecoderInfo(pThis, &pIDecoderInfo)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-
-    return IWICBitmapDecoderInfo(pUnk: pIDecoderInfo)
   }
 
   public func GetFrame(_ index: UINT) throws -> IWICBitmapFrameDecode {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapDecoder.self) { pThis in
+      var pIBitmapFrame: UnsafeMutablePointer<WinSDK.IWICBitmapFrameDecode>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetFrame(pThis, index, &pIBitmapFrame)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+
+      return IWICBitmapFrameDecode(pUnk: pIBitmapFrame)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapDecoder.self, capacity: 1)
-
-    var pIBitmapFrame: UnsafeMutablePointer<WinSDK.IWICBitmapFrameDecode>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetFrame(pThis, index, &pIBitmapFrame)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-
-    return IWICBitmapFrameDecode(pUnk: pIBitmapFrame)
   }
 
   public func GetFrameCount() throws -> UINT {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapDecoder.self) { pThis in
+      var Count: UINT = UINT(0)
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetFrameCount(pThis, &Count)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return Count
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapDecoder.self, capacity: 1)
-
-    var Count: UINT = UINT(0)
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetFrameCount(pThis, &Count)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return Count
   }
 
   public func GetMetadataQueryReader() throws -> IWICMetadataQueryReader {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapDecoder.self) { pThis in
+      var pIMetadataQueryReader: UnsafeMutablePointer<WinSDK.IWICMetadataQueryReader>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetMetadataQueryReader(pThis,
+                                                              &pIMetadataQueryReader)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+
+      return IWICMetadataQueryReader(pUnk: pIMetadataQueryReader)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapDecoder.self, capacity: 1)
-
-    var pIMetadataQueryReader: UnsafeMutablePointer<WinSDK.IWICMetadataQueryReader>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetMetadataQueryReader(pThis,
-                                                            &pIMetadataQueryReader)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-
-    return IWICMetadataQueryReader(pUnk: pIMetadataQueryReader)
   }
 
   public func GetPreview() throws -> IWICBitmapSource {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapDecoder.self) { pThis in
+      var pIBitmapSource: UnsafeMutablePointer<WinSDK.IWICBitmapSource>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetPreview(pThis, &pIBitmapSource)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+
+      return IWICBitmapSource(pUnk: pIBitmapSource)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapDecoder.self, capacity: 1)
-
-    var pIBitmapSource: UnsafeMutablePointer<WinSDK.IWICBitmapSource>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetPreview(pThis, &pIBitmapSource)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-
-    return IWICBitmapSource(pUnk: pIBitmapSource)
   }
 
   public func GetThumbnail() throws -> IWICBitmapSource {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapDecoder.self) { pThis in
+      var pIBitmapSource: UnsafeMutablePointer<WinSDK.IWICBitmapSource>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetThumbnail(pThis, &pIBitmapSource)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+
+      return IWICBitmapSource(pUnk: pIBitmapSource)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapDecoder.self, capacity: 1)
-
-    var pIBitmapSource: UnsafeMutablePointer<WinSDK.IWICBitmapSource>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetThumbnail(pThis, &pIBitmapSource)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-
-    return IWICBitmapSource(pUnk: pIBitmapSource)
   }
 
   public func Initialize(_ pStream: IStream,
                          _ cacheOptions: WICDecodeOptions) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapDecoder.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.Initialize(pThis, RawPointer(pStream),
+                                                  cacheOptions)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapDecoder.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.Initialize(pThis, RawPointer(pStream),
-                                                cacheOptions)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func QueryCapability(_ pStream: IStream) throws -> DWORD {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapDecoder.self) { pThis in
+      var dwCapability: DWORD = DWORD(0)
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.QueryCapability(pThis, RawPointer(pStream),
+                                                      &dwCapability)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return dwCapability
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapDecoder.self, capacity: 1)
-
-    var dwCapability: DWORD = DWORD(0)
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.QueryCapability(pThis, RawPointer(pStream),
-                                                     &dwCapability)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return dwCapability
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapDecoderInfo.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapDecoderInfo.swift
@@ -11,55 +11,43 @@ public class IWICBitmapDecoderInfo: IWICBitmapCodecInfo {
   override public class var IID: IID { IID_IWICBitmapDecoderInfo }
 
   public func CreateInstance() throws -> IWICBitmapDecoder {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapDecoderInfo.self) { pThis in
+      var pIBitmapDecoder: UnsafeMutablePointer<WinSDK.IWICBitmapDecoder>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.CreateInstance(pThis, &pIBitmapDecoder)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICBitmapDecoder(pUnk: pIBitmapDecoder)
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IWICBitmapDecoderInfo.self, capacity: 1)
-
-    var pIBitmapDecoder: UnsafeMutablePointer<WinSDK.IWICBitmapDecoder>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.CreateInstance(pThis, &pIBitmapDecoder)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICBitmapDecoder(pUnk: pIBitmapDecoder)
   }
 
   public func GetPatterns() throws -> [WICBitmapPattern] {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IWICBitmapDecoderInfo.self, capacity: 1)
-
-    var cPatterns: UINT = UINT(0)
-    var cbPatternsActual: UINT = UINT(0)
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetPatterns(pThis, 0, nil, &cPatterns,
-                                                 &cbPatternsActual)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-
-    return try Array<WICBitmapPattern>(unsafeUninitializedCapacity: Int(cPatterns)) {
+    return try perform(as: WinSDK.IWICBitmapDecoderInfo.self) { pThis in
+      var cPatterns: UINT = UINT(0)
+      var cbPatternsActual: UINT = UINT(0)
       let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetPatterns(pThis, UINT($0.count),
-                                                   $0.baseAddress, &cPatterns,
-                                                   &cbPatternsActual)
+          pThis.pointee.lpVtbl.pointee.GetPatterns(pThis, 0, nil, &cPatterns,
+                                                  &cbPatternsActual)
       guard hr == S_OK else { throw COMError(hr: hr) }
-      $1 = Int(cPatterns)
+
+      return try Array<WICBitmapPattern>(unsafeUninitializedCapacity: Int(cPatterns)) {
+        let hr: HRESULT =
+            pThis.pointee.lpVtbl.pointee.GetPatterns(pThis, UINT($0.count),
+                                                    $0.baseAddress, &cPatterns,
+                                                    &cbPatternsActual)
+        guard hr == S_OK else { throw COMError(hr: hr) }
+        $1 = Int(cPatterns)
+      }
     }
   }
 
   public func MatchesPattern(_ pIStream: IStream) throws -> Bool {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapDecoderInfo.self) { pThis in
+      var fMatches: WindowsBool = false
+      let hr: HRESULT =
+        pThis.pointee.lpVtbl.pointee.MatchesPattern(pThis, RawPointer(pIStream),
+                                                    &fMatches)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return fMatches == true
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IWICBitmapDecoderInfo.self, capacity: 1)
-
-    var fMatches: WindowsBool = false
-    let hr: HRESULT =
-      pThis.pointee.lpVtbl.pointee.MatchesPattern(pThis, RawPointer(pIStream),
-                                                  &fMatches)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return fMatches == true
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapEncoder.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapEncoder.swift
@@ -11,131 +11,101 @@ public class IWICBitmapEncoder: IUnknown {
   override public class var IID: IID { IID_IWICBitmapEncoder }
 
   public func Commit() throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapEncoder.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Commit(pThis)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapEncoder.self, capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Commit(pThis)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func CreateNewFrame() throws -> (IWICBitmapFrameEncode, IPropertyBag2) {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapEncoder.self) { pThis in
+      var pIFrameEncode: UnsafeMutablePointer<WinSDK.IWICBitmapFrameEncode>?
+      var pIEncoderOptions: UnsafeMutablePointer<WinSDK.IPropertyBag2>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.CreateNewFrame(pThis, &pIFrameEncode,
+                                                      &pIEncoderOptions)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return (IWICBitmapFrameEncode(pUnk: pIFrameEncode),
+              IPropertyBag2(pUnk: pIEncoderOptions))
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapEncoder.self, capacity: 1)
-
-    var pIFrameEncode: UnsafeMutablePointer<WinSDK.IWICBitmapFrameEncode>?
-    var pIEncoderOptions: UnsafeMutablePointer<WinSDK.IPropertyBag2>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.CreateNewFrame(pThis, &pIFrameEncode,
-                                                    &pIEncoderOptions)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return (IWICBitmapFrameEncode(pUnk: pIFrameEncode),
-            IPropertyBag2(pUnk: pIEncoderOptions))
   }
 
   public func GetContainerFormat() throws -> GUID {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapEncoder.self) { pThis in
+      var guidContainerFormat: GUID = GUID()
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetContainerFormat(pThis,
+                                                          &guidContainerFormat)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return guidContainerFormat
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapEncoder.self, capacity: 1)
-
-    var guidContainerFormat: GUID = GUID()
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetContainerFormat(pThis,
-                                                        &guidContainerFormat)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return guidContainerFormat
   }
 
   public func GetEncoderInfo() throws -> IWICBitmapEncoderInfo {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapEncoder.self) { pThis in
+      var pIEncoderInfo: UnsafeMutablePointer<WinSDK.IWICBitmapEncoderInfo>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetEncoderInfo(pThis, &pIEncoderInfo)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICBitmapEncoderInfo(pUnk: pIEncoderInfo)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapEncoder.self, capacity: 1)
-
-    var pIEncoderInfo: UnsafeMutablePointer<WinSDK.IWICBitmapEncoderInfo>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetEncoderInfo(pThis, &pIEncoderInfo)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICBitmapEncoderInfo(pUnk: pIEncoderInfo)
   }
 
   public func GetMetadataQueryWriter() throws -> IWICMetadataQueryWriter {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapEncoder.self) { pThis in
+      var pIMetadataQueryWriter: UnsafeMutablePointer<WinSDK.IWICMetadataQueryWriter>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetMetadataQueryWriter(pThis,
+                                                              &pIMetadataQueryWriter)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICMetadataQueryWriter(pUnk: pIMetadataQueryWriter)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapEncoder.self, capacity: 1)
-
-    var pIMetadataQueryWriter: UnsafeMutablePointer<WinSDK.IWICMetadataQueryWriter>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetMetadataQueryWriter(pThis,
-                                                            &pIMetadataQueryWriter)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICMetadataQueryWriter(pUnk: pIMetadataQueryWriter)
   }
 
   public func Initialize(_ pIStream: IStream,
                          _ cacheOption: WICBitmapEncoderCacheOption)
       throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapEncoder.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.Initialize(pThis, RawPointer(pIStream),
+                                                  cacheOption)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapEncoder.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.Initialize(pThis, RawPointer(pIStream),
-                                                cacheOption)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetColorContexts(_ contexts: [IWICColorContext]) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapEncoder.self) { pThis in
+      var pointers: [UnsafeMutablePointer<WinSDK.IWICColorContext>?] =
+          contexts.map { RawPointer($0) }
+      let hr: HRESULT = pointers.withUnsafeMutableBufferPointer {
+        pThis.pointee.lpVtbl.pointee.SetColorContexts(pThis, UINT($0.count),
+                                                      $0.baseAddress)
+      }
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapEncoder.self, capacity: 1)
-
-    var pointers: [UnsafeMutablePointer<WinSDK.IWICColorContext>?] =
-        contexts.map { RawPointer($0) }
-    let hr: HRESULT = pointers.withUnsafeMutableBufferPointer {
-      pThis.pointee.lpVtbl.pointee.SetColorContexts(pThis, UINT($0.count),
-                                                    $0.baseAddress)
-    }
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetPalette(_ pIPalette: IWICPalette) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapEncoder.self) { pThis in
+      let hr: HRESULT =
+        pThis.pointee.lpVtbl.pointee.SetPalette(pThis, RawPointer(pIPalette))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapEncoder.self, capacity: 1)
-
-    let hr: HRESULT =
-      pThis.pointee.lpVtbl.pointee.SetPalette(pThis, RawPointer(pIPalette))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetPreview(_ pIPreview: IWICBitmapSource) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapEncoder.self) { pThis in
+      let hr: HRESULT =
+        pThis.pointee.lpVtbl.pointee.SetPreview(pThis, RawPointer(pIPreview))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapEncoder.self, capacity: 1)
-
-    let hr: HRESULT =
-      pThis.pointee.lpVtbl.pointee.SetPreview(pThis, RawPointer(pIPreview))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetThumbnail(_ pIThumbnail: IWICBitmapSource) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapEncoder.self) { pThis in
+      let hr: HRESULT =
+        pThis.pointee.lpVtbl.pointee.SetThumbnail(pThis, RawPointer(pIThumbnail))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapEncoder.self, capacity: 1)
-
-    let hr: HRESULT =
-      pThis.pointee.lpVtbl.pointee.SetThumbnail(pThis, RawPointer(pIThumbnail))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapEncoderInfo.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapEncoderInfo.swift
@@ -11,15 +11,12 @@ public class IWICBitmapEncoderInfo: IWICBitmapCodecInfo {
   override public class var IID: IID { IID_IWICBitmapEncoderInfo }
 
   public func CreateInstance() throws -> IWICBitmapEncoder {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapEncoderInfo.self) { pThis in
+      var pIBitmapEncoder: UnsafeMutablePointer<WinSDK.IWICBitmapEncoder>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.CreateInstance(pThis, &pIBitmapEncoder)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICBitmapEncoder(pUnk: pIBitmapEncoder)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapEncoderInfo.self, capacity: 1)
-
-    var pIBitmapEncoder: UnsafeMutablePointer<WinSDK.IWICBitmapEncoder>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.CreateInstance(pThis, &pIBitmapEncoder)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICBitmapEncoder(pUnk: pIBitmapEncoder)
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapFlipRotator.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapFlipRotator.swift
@@ -12,14 +12,11 @@ public class IWICBitmapFlipRotator: IWICBitmapSource {
 
   public func Initialize(_ pISource: IWICBitmapSource,
                          _ options: WICBitmapTransformOptions) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapFlipRotator.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.Initialize(pThis, RawPointer(pISource),
+                                                  options)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapFlipRotator.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.Initialize(pThis, RawPointer(pISource),
-                                                options)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapFrameDecode.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapFrameDecode.swift
@@ -11,58 +11,46 @@ public class IWICBitmapFrameDecode: IWICBitmapSource {
   override public class var IID: IID { IID_IWICBitmapFrameDecode }
 
   public func GetColorContexts() throws -> [IWICColorContext] {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IWICBitmapFrameDecode.self, capacity: 1)
-
-    var cActualCount: UINT = UINT(0)
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetColorContexts(pThis, 0, nil,
-                                                      &cActualCount)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-
-    let contexts: [UnsafeMutablePointer<WinSDK.IWICColorContext>?] =
-        try .init(unsafeUninitializedCapacity: Int(cActualCount)) {
+    return try perform(as: WinSDK.IWICBitmapFrameDecode.self) { pThis in
+      var cActualCount: UINT = UINT(0)
       let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetColorContexts(pThis, cActualCount,
-                                                        $0.baseAddress,
+          pThis.pointee.lpVtbl.pointee.GetColorContexts(pThis, 0, nil,
                                                         &cActualCount)
       guard hr == S_OK else { throw COMError(hr: hr) }
-      $1 = Int(cActualCount)
-    }
 
-    return contexts.map { IWICColorContext(pUnk: $0) }
+      let contexts: [UnsafeMutablePointer<WinSDK.IWICColorContext>?] =
+          try .init(unsafeUninitializedCapacity: Int(cActualCount)) {
+        let hr: HRESULT =
+            pThis.pointee.lpVtbl.pointee.GetColorContexts(pThis, cActualCount,
+                                                          $0.baseAddress,
+                                                          &cActualCount)
+        guard hr == S_OK else { throw COMError(hr: hr) }
+        $1 = Int(cActualCount)
+      }
+
+      return contexts.map { IWICColorContext(pUnk: $0) }
+    }
   }
 
   public func GetMetadataQueryReader() throws -> IWICMetadataQueryReader {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapFrameDecode.self) { pThis in
+      var pIMetadataQueryReader: UnsafeMutablePointer<WinSDK.IWICMetadataQueryReader>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetMetadataQueryReader(pThis,
+                                                              &pIMetadataQueryReader)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICMetadataQueryReader(pUnk: pIMetadataQueryReader)
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IWICBitmapFrameDecode.self, capacity: 1)
-
-    var pIMetadataQueryReader: UnsafeMutablePointer<WinSDK.IWICMetadataQueryReader>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetMetadataQueryReader(pThis,
-                                                            &pIMetadataQueryReader)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICMetadataQueryReader(pUnk: pIMetadataQueryReader)
   }
 
   public func GetThumbnail() throws -> IWICBitmapSource {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapFrameDecode.self) { pThis in
+      var pIBitmapSource: UnsafeMutablePointer<WinSDK.IWICBitmapSource>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetThumbnail(pThis, &pIBitmapSource)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+
+      return IWICBitmapSource(pUnk: pIBitmapSource)
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IWICBitmapFrameDecode.self, capacity: 1)
-
-    var pIBitmapSource: UnsafeMutablePointer<WinSDK.IWICBitmapSource>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetThumbnail(pThis, &pIBitmapSource)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-
-    return IWICBitmapSource(pUnk: pIBitmapSource)
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapFrameEncode.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapFrameEncode.swift
@@ -11,135 +11,102 @@ public class IWICBitmapFrameEncode: IUnknown {
   override public class var IID: IID { IID_IWICBitmapFrameEncode }
 
   public func Commit() throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapFrameEncode.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Commit(pThis)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapFrameEncode.self, capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Commit(pThis)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func GetMetadataQueryWriter() throws -> IWICMetadataQueryWriter {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapFrameEncode.self) { pThis in
+      var pIMetadataQueryWriter: UnsafeMutablePointer<WinSDK.IWICMetadataQueryWriter>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetMetadataQueryWriter(pThis,
+                                                              &pIMetadataQueryWriter)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICMetadataQueryWriter(pUnk: pIMetadataQueryWriter)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapFrameEncode.self, capacity: 1)
-
-    var pIMetadataQueryWriter: UnsafeMutablePointer<WinSDK.IWICMetadataQueryWriter>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetMetadataQueryWriter(pThis,
-                                                            &pIMetadataQueryWriter)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICMetadataQueryWriter(pUnk: pIMetadataQueryWriter)
   }
 
   public func Initialize(_ pIEncoderOptions: IPropertyBag2) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapFrameEncode.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.Initialize(pThis,
+                                                  RawPointer(pIEncoderOptions))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapFrameEncode.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.Initialize(pThis,
-                                                RawPointer(pIEncoderOptions))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetColorContexts(_ contexts: [IWICColorContext]) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapFrameEncode.self) { pThis in
+      var pointers: [UnsafeMutablePointer<WinSDK.IWICColorContext>?] =
+          contexts.map { RawPointer($0) }
+      let hr: HRESULT = pointers.withUnsafeMutableBufferPointer {
+        pThis.pointee.lpVtbl.pointee.SetColorContexts(pThis, UINT($0.count),
+                                                      $0.baseAddress)
+      }
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapFrameEncode.self, capacity: 1)
-
-    var pointers: [UnsafeMutablePointer<WinSDK.IWICColorContext>?] =
-        contexts.map { RawPointer($0) }
-    let hr: HRESULT = pointers.withUnsafeMutableBufferPointer {
-      pThis.pointee.lpVtbl.pointee.SetColorContexts(pThis, UINT($0.count),
-                                                    $0.baseAddress)
-    }
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetPalette(_ pIPalette: IWICPalette) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapFrameEncode.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.SetPalette(pThis, RawPointer(pIPalette))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapFrameEncode.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetPalette(pThis, RawPointer(pIPalette))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetPixelFormat(_ pPixelFormat: inout WICPixelFormatGUID) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapFrameEncode.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.SetPixelFormat(pThis, &pPixelFormat)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapFrameEncode.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetPixelFormat(pThis, &pPixelFormat)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetResolution(_ dpiX: Double, _ dpiY: Double) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapFrameEncode.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.SetResolution(pThis, dpiX, dpiY)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapFrameEncode.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetResolution(pThis, dpiX, dpiY)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetSize(_ uiWidth: UINT, _ uiHeight: UINT) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapFrameEncode.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.SetSize(pThis, uiWidth, uiHeight)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapFrameEncode.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetSize(pThis, uiWidth, uiHeight)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetThumbnail(_ pIThumbnail: IWICBitmapSource) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapFrameEncode.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.SetThumbnail(pThis,
+                                                    RawPointer(pIThumbnail))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapFrameEncode.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetThumbnail(pThis,
-                                                  RawPointer(pIThumbnail))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func WritePixels(_ lineCount: UINT, _ cbStride: UINT, _ pixels: inout [BYTE]) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapFrameEncode.self) { pThis in
+      let hr: HRESULT = pixels.withUnsafeMutableBufferPointer {
+        pThis.pointee.lpVtbl.pointee.WritePixels(pThis, lineCount, cbStride,
+                                                UINT($0.count), $0.baseAddress)
+      }
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapFrameEncode.self, capacity: 1)
-
-    let hr: HRESULT = pixels.withUnsafeMutableBufferPointer {
-      pThis.pointee.lpVtbl.pointee.WritePixels(pThis, lineCount, cbStride,
-                                               UINT($0.count), $0.baseAddress)
-    }
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func WriteSource(_ pIBitmapSource: IWICBitmapSource, _ rc: inout WICRect) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapFrameEncode.self) { pThis in
+      let hr: HRESULT = withUnsafeMutablePointer(to: &rc) {
+        pThis.pointee.lpVtbl.pointee.WriteSource(pThis,
+                                                RawPointer(pIBitmapSource), $0)
+      }
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapFrameEncode.self, capacity: 1)
-
-    let hr: HRESULT = withUnsafeMutablePointer(to: &rc) {
-      pThis.pointee.lpVtbl.pointee.WriteSource(pThis,
-                                               RawPointer(pIBitmapSource), $0)
-    }
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapLock.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapLock.swift
@@ -11,57 +11,45 @@ public class IWICBitmapLock: IUnknown {
   override public class var IID: IID { IID_IWICBitmapLock }
 
   public func GetDataPointer() throws -> [BYTE] {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapLock.self) { pThis in
+      var cbBufferSize: UINT = UINT(0)
+      var pbData: WICInProcPointer?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetDataPointer(pThis, &cbBufferSize,
+                                                      &pbData)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return Array<BYTE>(UnsafeBufferPointer<BYTE>(start: pbData,
+                                                  count: Int(cbBufferSize)))
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapLock.self, capacity: 1)
-
-    var cbBufferSize: UINT = UINT(0)
-    var pbData: WICInProcPointer?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetDataPointer(pThis, &cbBufferSize,
-                                                    &pbData)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return Array<BYTE>(UnsafeBufferPointer<BYTE>(start: pbData,
-                                                 count: Int(cbBufferSize)))
   }
 
   public func GetPixelFormat() throws -> WICPixelFormatGUID {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapLock.self) { pThis in
+      var PixelFormat: WICPixelFormatGUID = WICPixelFormatGUID()
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetPixelFormat(pThis, &PixelFormat)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return PixelFormat
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapLock.self, capacity: 1)
-
-    var PixelFormat: WICPixelFormatGUID = WICPixelFormatGUID()
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetPixelFormat(pThis, &PixelFormat)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return PixelFormat
   }
 
   public func GetSize() throws -> (UINT, UINT) {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapLock.self) { pThis in
+      var uiWidth: UINT = UINT(0)
+      var uiHeight: UINT = UINT(0)
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetSize(pThis, &uiWidth, &uiHeight)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return (uiWidth, uiHeight)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapLock.self, capacity: 1)
-
-    var uiWidth: UINT = UINT(0)
-    var uiHeight: UINT = UINT(0)
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetSize(pThis, &uiWidth, &uiHeight)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return (uiWidth, uiHeight)
   }
 
   public func GetStride() throws -> UINT {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapLock.self) { pThis in
+      var cbStride: UINT = UINT(0)
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetStride(pThis, &cbStride)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return cbStride
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapLock.self, capacity: 1)
-
-    var cbStride: UINT = UINT(0)
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetStride(pThis, &cbStride)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return cbStride
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapScaler.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapScaler.swift
@@ -13,14 +13,11 @@ public class IWICBitmapScaler: IWICBitmapSource {
   public func Initialize(_ pISource: IWICBitmapSource, _ uiWidth: UINT,
                          _ uiHeight: UINT,
                          _ mode: WICBitmapInterpolationMode) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapScaler.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.Initialize(pThis, RawPointer(pISource),
+                                                  uiWidth, uiHeight, mode)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapScaler.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.Initialize(pThis, RawPointer(pISource),
-                                                uiWidth, uiHeight, mode)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapSource.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapSource.swift
@@ -11,74 +11,59 @@ public class IWICBitmapSource: IUnknown {
   override public class var IID: IID { IID_IWICBitmapSource }
 
   public func CopyPalette(_ pIPalette: IWICPalette) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapSource.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.CopyPalette(pThis, RawPointer(pIPalette))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapSource.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.CopyPalette(pThis, RawPointer(pIPalette))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func CopyPixels(_ rc: WICRect?, _ cbStride: UINT,
                          _ pbBuffer: UnsafeMutableBufferPointer<BYTE>) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapSource.self) { pThis in
+      let hr: HRESULT
+      if var rc = rc {
+        hr = pThis.pointee.lpVtbl.pointee.CopyPixels(pThis, &rc, cbStride,
+                                                     UINT(pbBuffer.count),
+                                                     pbBuffer.baseAddress)
+      } else {
+        hr = pThis.pointee.lpVtbl.pointee.CopyPixels(pThis, nil, cbStride,
+                                                     UINT(pbBuffer.count),
+                                                     pbBuffer.baseAddress)
+      }
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapSource.self, capacity: 1)
-
-    let hr: HRESULT
-    if var rc = rc {
-      hr = pThis.pointee.lpVtbl.pointee.CopyPixels(pThis, &rc, cbStride,
-                                                   UINT(pbBuffer.count),
-                                                   pbBuffer.baseAddress)
-    } else {
-      hr = pThis.pointee.lpVtbl.pointee.CopyPixels(pThis, nil, cbStride,
-                                                   UINT(pbBuffer.count),
-                                                   pbBuffer.baseAddress)
-    }
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func GetPixelFormat() throws -> WICPixelFormatGUID {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapSource.self) { pThis in
+      var PixelFormat: WICPixelFormatGUID = WICPixelFormatGUID()
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetPixelFormat(pThis, &PixelFormat)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return PixelFormat
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapSource.self, capacity: 1)
-
-    var PixelFormat: WICPixelFormatGUID = WICPixelFormatGUID()
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetPixelFormat(pThis, &PixelFormat)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return PixelFormat
   }
 
   public func GetResolution() throws -> (Double, Double) {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapSource.self) { pThis in
+      var DpiX: Double = 0.0
+      var DpiY: Double = 0.0
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetResolution(pThis, &DpiX, &DpiY)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return (DpiX, DpiY)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapSource.self, capacity: 1)
-
-    var DpiX: Double = 0.0
-    var DpiY: Double = 0.0
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetResolution(pThis, &DpiX, &DpiY)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return (DpiX, DpiY)
   }
 
   public func GetSize() throws -> (UINT, UINT) {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICBitmapSource.self) { pThis in
+      var uiWidth: UINT = UINT(0)
+      var uiHeight: UINT = UINT(0)
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetSize(pThis, &uiWidth, &uiHeight)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return (uiWidth, uiHeight)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICBitmapSource.self, capacity: 1)
-
-    var uiWidth: UINT = UINT(0)
-    var uiHeight: UINT = UINT(0)
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetSize(pThis, &uiWidth, &uiHeight)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return (uiWidth, uiHeight)
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICColorContext.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICColorContext.swift
@@ -11,83 +11,65 @@ public class IWICColorContext: IUnknown {
   override public class var IID: IID { IID_IWICColorContext }
 
   public func GetExifColorSpace() throws -> UINT {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICColorContext.self) { pThis in
+      var Value: UINT = UINT(0)
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetExifColorSpace(pThis, &Value)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return Value
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICColorContext.self, capacity: 1)
-
-    var Value: UINT = UINT(0)
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetExifColorSpace(pThis, &Value)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return Value
   }
 
   public func GetProfileBytes() throws -> [BYTE] {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICColorContext.self, capacity: 1)
-
-    var cbActual: UINT = UINT(0)
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetProfileBytes(pThis, 0, nil, &cbActual)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-
-    return try Array<BYTE>(unsafeUninitializedCapacity: Int(cbActual)) {
+    return try perform(as: WinSDK.IWICColorContext.self) { pThis in
+      var cbActual: UINT = UINT(0)
       let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetProfileBytes(pThis, UINT($0.count),
-                                                       $0.baseAddress, &cbActual)
+          pThis.pointee.lpVtbl.pointee.GetProfileBytes(pThis, 0, nil, &cbActual)
       guard hr == S_OK else { throw COMError(hr: hr) }
-      $1 = Int(cbActual)
+
+      return try Array<BYTE>(unsafeUninitializedCapacity: Int(cbActual)) {
+        let hr: HRESULT =
+            pThis.pointee.lpVtbl.pointee.GetProfileBytes(pThis, UINT($0.count),
+                                                        $0.baseAddress, &cbActual)
+        guard hr == S_OK else { throw COMError(hr: hr) }
+        $1 = Int(cbActual)
+      }
     }
   }
 
   public func GetType() throws -> WICColorContextType {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICColorContext.self) { pThis in
+      var Type: WICColorContextType = WICColorContextType(0)
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetType(pThis, &Type)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return Type
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICColorContext.self, capacity: 1)
-
-    var Type: WICColorContextType = WICColorContextType(0)
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetType(pThis, &Type)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return Type
   }
 
   public func InitializeFromExifColorSpace(_ value: UINT) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICColorContext.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.InitializeFromExifColorSpace(pThis, value)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICColorContext.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.InitializeFromExifColorSpace(pThis, value)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func InitializeFromFilename(_ filename: String) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICColorContext.self) { pThis in
+      let hr: HRESULT = filename.withCString(encodedAs: UTF16.self) {
+        pThis.pointee.lpVtbl.pointee.InitializeFromFilename(pThis, $0)
+      }
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICColorContext.self, capacity: 1)
-
-    let hr: HRESULT = filename.withCString(encodedAs: UTF16.self) {
-      pThis.pointee.lpVtbl.pointee.InitializeFromFilename(pThis, $0)
-    }
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func InitializeFromMemory(_ pbBuffer: [BYTE]) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICColorContext.self) { pThis in
+      let hr: HRESULT = pbBuffer.withUnsafeBufferPointer {
+        pThis.pointee.lpVtbl.pointee.InitializeFromMemory(pThis, $0.baseAddress,
+                                                          UINT($0.count))
+      }
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICColorContext.self, capacity: 1)
-
-    let hr: HRESULT = pbBuffer.withUnsafeBufferPointer {
-      pThis.pointee.lpVtbl.pointee.InitializeFromMemory(pThis, $0.baseAddress,
-                                                        UINT($0.count))
-    }
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICColorTransform.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICColorTransform.swift
@@ -14,16 +14,13 @@ public class IWICColorTransform: IWICBitmapSource {
                          _ pIContextSource: IWICColorContext,
                          _ pIContextDest: IWICColorContext,
                          _ pixelFmtDest: REFWICPixelFormatGUID) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICColorTransform.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.Initialize(pThis, RawPointer(pISource),
+                                                  RawPointer(pIContextSource),
+                                                  RawPointer(pIContextDest),
+                                                  pixelFmtDest)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICColorTransform.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.Initialize(pThis, RawPointer(pISource),
-                                                RawPointer(pIContextSource),
-                                                RawPointer(pIContextDest),
-                                                pixelFmtDest)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICComponentInfo.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICComponentInfo.swift
@@ -11,143 +11,119 @@ public class IWICComponentInfo: IUnknown {
   override public class var IID: IID { IID_IWICComponentInfo }
 
   public func GetAuthor() throws -> String? {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICComponentInfo.self, capacity: 1)
-
-    var cchActual: UINT = UINT(0)
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetAuthor(pThis, 0, nil, &cchActual)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-
-    guard cchActual > 0 else { return nil }
-
-    let buffer: [WCHAR] =
-        try Array<WCHAR>(unsafeUninitializedCapacity: Int(cchActual)) {
+    return try perform(as: WinSDK.IWICComponentInfo.self) { pThis in
+      var cchActual: UINT = UINT(0)
       let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetAuthor(pThis, UINT($0.count),
-                                                 $0.baseAddress, &cchActual)
+          pThis.pointee.lpVtbl.pointee.GetAuthor(pThis, 0, nil, &cchActual)
       guard hr == S_OK else { throw COMError(hr: hr) }
-      $1 = Int(cchActual)
+
+      guard cchActual > 0 else { return nil }
+
+      let buffer: [WCHAR] =
+          try Array<WCHAR>(unsafeUninitializedCapacity: Int(cchActual)) {
+        let hr: HRESULT =
+            pThis.pointee.lpVtbl.pointee.GetAuthor(pThis, UINT($0.count),
+                                                  $0.baseAddress, &cchActual)
+        guard hr == S_OK else { throw COMError(hr: hr) }
+        $1 = Int(cchActual)
+      }
+      return String(decoding: buffer, as: UTF16.self)
     }
-    return String(decoding: buffer, as: UTF16.self)
   }
 
   public func GetCLSID() throws -> CLSID {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICComponentInfo.self) { pThis in
+      var clsid: CLSID = CLSID()
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetCLSID(pThis, &clsid)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return clsid
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICComponentInfo.self, capacity: 1)
-
-    var clsid: CLSID = CLSID()
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetCLSID(pThis, &clsid)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return clsid
   }
 
   public func GetComponentType() throws -> WICComponentType {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICComponentInfo.self) { pThis in
+      var Type: WICComponentType = WICComponentType(0)
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetComponentType(pThis, &Type)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return Type
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICComponentInfo.self, capacity: 1)
-
-    var Type: WICComponentType = WICComponentType(0)
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetComponentType(pThis, &Type)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return Type
   }
 
   public func GetFriendlyName() throws -> String {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICComponentInfo.self, capacity: 1)
-
-    var cchActual: UINT = UINT(0)
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetFriendlyName(pThis, 0, nil, &cchActual)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-
-    let buffer: [WCHAR] =
-        try Array<WCHAR>(unsafeUninitializedCapacity: Int(cchActual)) {
+    return try perform(as: WinSDK.IWICComponentInfo.self) { pThis in
+      var cchActual: UINT = UINT(0)
       let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetFriendlyName(pThis, UINT($0.count),
-                                                       $0.baseAddress,
-                                                       &cchActual)
+          pThis.pointee.lpVtbl.pointee.GetFriendlyName(pThis, 0, nil, &cchActual)
       guard hr == S_OK else { throw COMError(hr: hr) }
-      $1 = Int(cchActual)
+
+      let buffer: [WCHAR] =
+          try Array<WCHAR>(unsafeUninitializedCapacity: Int(cchActual)) {
+        let hr: HRESULT =
+            pThis.pointee.lpVtbl.pointee.GetFriendlyName(pThis, UINT($0.count),
+                                                        $0.baseAddress,
+                                                        &cchActual)
+        guard hr == S_OK else { throw COMError(hr: hr) }
+        $1 = Int(cchActual)
+      }
+      return String(decoding: buffer, as: UTF16.self)
     }
-    return String(decoding: buffer, as: UTF16.self)
   }
 
   public func GetSigningStatus() throws -> DWORD {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICComponentInfo.self) { pThis in
+      var Status: DWORD = DWORD(0)
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetSigningStatus(pThis, &Status)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return Status
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICComponentInfo.self, capacity: 1)
-
-    var Status: DWORD = DWORD(0)
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetSigningStatus(pThis, &Status)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return Status
   }
 
   public func GetSpecVersion() throws -> String {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICComponentInfo.self, capacity: 1)
-
-    var cchActual: UINT = UINT(0)
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetSpecVersion(pThis, 0, nil, &cchActual)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-
-    let buffer: [WCHAR] =
-        try Array<WCHAR>(unsafeUninitializedCapacity: Int(cchActual)) {
+    return try perform(as: WinSDK.IWICComponentInfo.self) { pThis in
+      var cchActual: UINT = UINT(0)
       let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetSpecVersion(pThis, UINT($0.count),
-                                                      $0.baseAddress, &cchActual)
+          pThis.pointee.lpVtbl.pointee.GetSpecVersion(pThis, 0, nil, &cchActual)
       guard hr == S_OK else { throw COMError(hr: hr) }
-      $1 = Int(cchActual)
+
+      let buffer: [WCHAR] =
+          try Array<WCHAR>(unsafeUninitializedCapacity: Int(cchActual)) {
+        let hr: HRESULT =
+            pThis.pointee.lpVtbl.pointee.GetSpecVersion(pThis, UINT($0.count),
+                                                        $0.baseAddress, &cchActual)
+        guard hr == S_OK else { throw COMError(hr: hr) }
+        $1 = Int(cchActual)
+      }
+      return String(decoding: buffer, as: UTF16.self)
     }
-    return String(decoding: buffer, as: UTF16.self)
   }
 
   public func GetVendorGUID() throws -> GUID {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICComponentInfo.self) { pThis in
+      var guidVendor: GUID = GUID()
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetVendorGUID(pThis, &guidVendor)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return guidVendor
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICComponentInfo.self, capacity: 1)
-
-    var guidVendor: GUID = GUID()
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetVendorGUID(pThis, &guidVendor)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return guidVendor
   }
 
   public func GetVersion() throws -> String {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICComponentInfo.self, capacity: 1)
-
-    var cchActual: UINT = UINT(0)
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetVersion(pThis, 0, nil, &cchActual)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-
-    let buffer: [WCHAR] =
-        try Array<WCHAR>(unsafeUninitializedCapacity: Int(cchActual)) {
+    return try perform(as: WinSDK.IWICComponentInfo.self) { pThis in
+      var cchActual: UINT = UINT(0)
       let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetVersion(pThis, UINT($0.count),
-                                                  $0.baseAddress, &cchActual)
+          pThis.pointee.lpVtbl.pointee.GetVersion(pThis, 0, nil, &cchActual)
       guard hr == S_OK else { throw COMError(hr: hr) }
-      $1 = Int(cchActual)
+
+      let buffer: [WCHAR] =
+          try Array<WCHAR>(unsafeUninitializedCapacity: Int(cchActual)) {
+        let hr: HRESULT =
+            pThis.pointee.lpVtbl.pointee.GetVersion(pThis, UINT($0.count),
+                                                    $0.baseAddress, &cchActual)
+        guard hr == S_OK else { throw COMError(hr: hr) }
+        $1 = Int(cchActual)
+      }
+      return String(decoding: buffer, as: UTF16.self)
     }
-    return String(decoding: buffer, as: UTF16.self)
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICFastMetadataEncoder.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICFastMetadataEncoder.swift
@@ -11,26 +11,20 @@ public class IWICFastMetadataEncoder: IUnknown {
   override public class var IID: IID { IID_IWICFastMetadataEncoder }
 
   public func Commit() throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICFastMetadataEncoder.self) { pThis in
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Commit(pThis)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICFastMetadataEncoder.self, capacity: 1)
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Commit(pThis)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func GetMetadataQueryWriter() throws -> IWICMetadataQueryWriter {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICFastMetadataEncoder.self) { pThis in
+      var pIMetadataQueryWriter: UnsafeMutablePointer<WinSDK.IWICMetadataQueryWriter>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetMetadataQueryWriter(pThis,
+                                                              &pIMetadataQueryWriter)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICMetadataQueryWriter(pUnk: pIMetadataQueryWriter)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICFastMetadataEncoder.self, capacity: 1)
-
-    var pIMetadataQueryWriter: UnsafeMutablePointer<WinSDK.IWICMetadataQueryWriter>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetMetadataQueryWriter(pThis,
-                                                            &pIMetadataQueryWriter)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICMetadataQueryWriter(pUnk: pIMetadataQueryWriter)
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICFormatConverter.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICFormatConverter.swift
@@ -13,18 +13,15 @@ public class IWICFormatConverter: IWICBitmapSource {
   public func CanConvert(_ srcPixelFormat: REFWICPixelFormatGUID,
                          _ dstPixelFormat: REFWICPixelFormatGUID)
       throws -> Bool {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICFormatConverter.self) { pThis in
+      var fCanConvert: WindowsBool = false
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.CanConvert(pThis, srcPixelFormat,
+                                                  dstPixelFormat,
+                                                  &fCanConvert)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return fCanConvert == true
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICFormatConverter.self, capacity: 1)
-
-    var fCanConvert: WindowsBool = false
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.CanConvert(pThis, srcPixelFormat,
-                                                dstPixelFormat,
-                                                &fCanConvert)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return fCanConvert == true
   }
 
   public func Initialize(_ pISource: IWICBitmapSource,
@@ -33,18 +30,15 @@ public class IWICFormatConverter: IWICBitmapSource {
                          _ pIPalette: IWICPalette?,
                          _ alphaThresholdPercent: Double,
                          _ paletteTranslate: WICBitmapPaletteType) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICFormatConverter.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.Initialize(pThis, RawPointer(pISource),
+                                                  dstFormat, dither,
+                                                  RawPointer(pIPalette),
+                                                  alphaThresholdPercent,
+                                                  paletteTranslate)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICFormatConverter.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.Initialize(pThis, RawPointer(pISource),
-                                                dstFormat, dither,
-                                                RawPointer(pIPalette),
-                                                alphaThresholdPercent,
-                                                paletteTranslate)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }
 

--- a/Sources/SwiftCOM/Interfaces/Human/IWICImagingFactory.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICImagingFactory.swift
@@ -14,250 +14,205 @@ public class IWICImagingFactory: IUnknown {
                            _ pixelFormat: REFWICPixelFormatGUID,
                            _ option: WICBitmapCreateCacheOption)
       throws -> IWICBitmap {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
+      var pIBitmap: UnsafeMutablePointer<WinSDK.IWICBitmap>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.CreateBitmap(pThis, uiWidth, uiHeight,
+                                                    pixelFormat, option, &pIBitmap)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICBitmap(pUnk: pIBitmap)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICImagingFactory.self, capacity: 1)
-
-    var pIBitmap: UnsafeMutablePointer<WinSDK.IWICBitmap>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.CreateBitmap(pThis, uiWidth, uiHeight,
-                                                  pixelFormat, option, &pIBitmap)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICBitmap(pUnk: pIBitmap)
   }
 
   public func CreateBitmapClipper() throws -> IWICBitmapClipper {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
+      var pIBitmapClipper: UnsafeMutablePointer<WinSDK.IWICBitmapClipper>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.CreateBitmapClipper(pThis, &pIBitmapClipper)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICBitmapClipper(pUnk: pIBitmapClipper)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICImagingFactory.self, capacity: 1)
-
-    var pIBitmapClipper: UnsafeMutablePointer<WinSDK.IWICBitmapClipper>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.CreateBitmapClipper(pThis, &pIBitmapClipper)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICBitmapClipper(pUnk: pIBitmapClipper)
   }
 
   public func CreateBitmapFlipRotator() throws -> IWICBitmapFlipRotator {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
+      var pIBitmapFlipRotator: UnsafeMutablePointer<WinSDK.IWICBitmapFlipRotator>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.CreateBitmapFlipRotator(pThis,
+                                                               &pIBitmapFlipRotator)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICBitmapFlipRotator(pUnk: pIBitmapFlipRotator)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICImagingFactory.self, capacity: 1)
-
-    var pIBitmapFlipRotator: UnsafeMutablePointer<WinSDK.IWICBitmapFlipRotator>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.CreateBitmapFlipRotator(pThis,
-                                                             &pIBitmapFlipRotator)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICBitmapFlipRotator(pUnk: pIBitmapFlipRotator)
   }
 
   public func CreateBitmapFromHBITMAP(_ hBitmap: HBITMAP, _ hPalette: HPALETTE,
                                       _ option: WICBitmapAlphaChannelOption)
       throws -> IWICBitmap {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
+      var pIBitmap: UnsafeMutablePointer<WinSDK.IWICBitmap>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.CreateBitmapFromHBITMAP(pThis, hBitmap,
+                                                              hPalette, option,
+                                                              &pIBitmap)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICBitmap(pUnk: pIBitmap)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICImagingFactory.self, capacity: 1)
-
-    var pIBitmap: UnsafeMutablePointer<WinSDK.IWICBitmap>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.CreateBitmapFromHBITMAP(pThis, hBitmap,
-                                                             hPalette, option,
-                                                             &pIBitmap)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICBitmap(pUnk: pIBitmap)
   }
 
   public func CreateBitmapFromHICON(_ hIcon: HICON) throws -> IWICBitmap {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
+      var pIBitmap: UnsafeMutablePointer<WinSDK.IWICBitmap>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.CreateBitmapFromHICON(pThis, hIcon, &pIBitmap)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICBitmap(pUnk: pIBitmap)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICImagingFactory.self, capacity: 1)
-
-    var pIBitmap: UnsafeMutablePointer<WinSDK.IWICBitmap>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.CreateBitmapFromHICON(pThis, hIcon, &pIBitmap)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICBitmap(pUnk: pIBitmap)
   }
 
   public func CreateBitmapFromMemory(_ uiWidth: UINT, _ uiHeight: UINT,
                                      _ pixelFormat: REFWICPixelFormatGUID,
                                      _ cbStride: UINT, _ pbBuffer: inout [BYTE])
       throws -> IWICBitmap {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
+      var pIBitmap: UnsafeMutablePointer<WinSDK.IWICBitmap>?
+      let hr: HRESULT = pbBuffer.withUnsafeMutableBufferPointer {
+        pThis.pointee.lpVtbl.pointee.CreateBitmapFromMemory(pThis, uiWidth, uiHeight,
+                                                            pixelFormat, cbStride,
+                                                            UINT($0.count),
+                                                            $0.baseAddress,
+                                                            &pIBitmap)
+      }
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICBitmap(pUnk: pIBitmap)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICImagingFactory.self, capacity: 1)
-
-    var pIBitmap: UnsafeMutablePointer<WinSDK.IWICBitmap>?
-    let hr: HRESULT = pbBuffer.withUnsafeMutableBufferPointer {
-      pThis.pointee.lpVtbl.pointee.CreateBitmapFromMemory(pThis, uiWidth, uiHeight,
-                                                          pixelFormat, cbStride,
-                                                          UINT($0.count),
-                                                          $0.baseAddress,
-                                                          &pIBitmap)
-    }
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICBitmap(pUnk: pIBitmap)
   }
 
   public func CreateBitmapFromSource(_ pIBitmapSource: IWICBitmapSource,
                                      _ option: WICBitmapCreateCacheOption)
       throws -> IWICBitmap {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
+      var pIBitmap: UnsafeMutablePointer<WinSDK.IWICBitmap>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.CreateBitmapFromSource(pThis,
+                                                              RawPointer(pIBitmapSource),
+                                                              option, &pIBitmap)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICBitmap(pUnk: pIBitmap)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICImagingFactory.self, capacity: 1)
-
-    var pIBitmap: UnsafeMutablePointer<WinSDK.IWICBitmap>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.CreateBitmapFromSource(pThis,
-                                                            RawPointer(pIBitmapSource),
-                                                            option, &pIBitmap)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICBitmap(pUnk: pIBitmap)
   }
 
   public func CreateBitmapFromSourceRect(_ pIBitmapSource: IWICBitmapSource,
                                          _ x: UINT, _ y: UINT, _ width: UINT,
                                          _ height: UINT) throws -> IWICBitmap {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
+      var pIBitmap: UnsafeMutablePointer<WinSDK.IWICBitmap>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.CreateBitmapFromSourceRect(pThis,
+                                                                  RawPointer(pIBitmapSource),
+                                                                  x, y, width,
+                                                                  height,
+                                                                  &pIBitmap)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICBitmap(pUnk: pIBitmap)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICImagingFactory.self, capacity: 1)
-
-    var pIBitmap: UnsafeMutablePointer<WinSDK.IWICBitmap>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.CreateBitmapFromSourceRect(pThis,
-                                                                RawPointer(pIBitmapSource),
-                                                                x, y, width,
-                                                                height,
-                                                                &pIBitmap)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICBitmap(pUnk: pIBitmap)
   }
 
   public func CreateBitmapScaler() throws -> IWICBitmapScaler {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
+      var pIBitmapScaler: UnsafeMutablePointer<WinSDK.IWICBitmapScaler>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.CreateBitmapScaler(pThis, &pIBitmapScaler)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICBitmapScaler(pUnk: pIBitmapScaler)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICImagingFactory.self, capacity: 1)
-
-    var pIBitmapScaler: UnsafeMutablePointer<WinSDK.IWICBitmapScaler>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.CreateBitmapScaler(pThis, &pIBitmapScaler)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICBitmapScaler(pUnk: pIBitmapScaler)
   }
 
   public func CreateColorContext() throws -> IWICColorContext {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
+      var pIWICColorContext: UnsafeMutablePointer<WinSDK.IWICColorContext>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.CreateColorContext(pThis,
+                                                          &pIWICColorContext)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICColorContext(pUnk: pIWICColorContext)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICImagingFactory.self, capacity: 1)
-
-    var pIWICColorContext: UnsafeMutablePointer<WinSDK.IWICColorContext>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.CreateColorContext(pThis,
-                                                        &pIWICColorContext)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICColorContext(pUnk: pIWICColorContext)
   }
 
   public func CreateColorTransformer() throws -> IWICColorTransform {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
+      var pIWICColorTransform: UnsafeMutablePointer<WinSDK.IWICColorTransform>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.CreateColorTransformer(pThis,
+                                                              &pIWICColorTransform)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICColorTransform(pUnk: pIWICColorTransform)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICImagingFactory.self, capacity: 1)
-
-    var pIWICColorTransform: UnsafeMutablePointer<WinSDK.IWICColorTransform>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.CreateColorTransformer(pThis,
-                                                            &pIWICColorTransform)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICColorTransform(pUnk: pIWICColorTransform)
   }
 
   public func CreateComponentEnumerator(_ componentTypes: DWORD,
                                         _ options: DWORD)
       throws -> IEnumUnknown {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
+      var pIEnumUnknown: UnsafeMutablePointer<WinSDK.IEnumUnknown>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.CreateComponentEnumerator(pThis,
+                                                                 componentTypes,
+                                                                 options,
+                                                                 &pIEnumUnknown)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IEnumUnknown(pUnk: pIEnumUnknown)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICImagingFactory.self, capacity: 1)
-
-    var pIEnumUnknown: UnsafeMutablePointer<WinSDK.IEnumUnknown>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.CreateComponentEnumerator(pThis,
-                                                               componentTypes,
-                                                               options,
-                                                               &pIEnumUnknown)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IEnumUnknown(pUnk: pIEnumUnknown)
   }
 
   public func CreateComponentInfo(_ clsidComponent: REFCLSID)
       throws -> IWICComponentInfo {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
+      var pIInfo: UnsafeMutablePointer<WinSDK.IWICComponentInfo>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.CreateComponentInfo(pThis, clsidComponent,
+                                                           &pIInfo)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICComponentInfo(pUnk: pIInfo)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICImagingFactory.self, capacity: 1)
-
-    var pIInfo: UnsafeMutablePointer<WinSDK.IWICComponentInfo>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.CreateComponentInfo(pThis, clsidComponent,
-                                                         &pIInfo)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICComponentInfo(pUnk: pIInfo)
   }
 
   public func CreateDecoder(_ guidContainerFormat: REFGUID,
                             _ guidVendor: GUID?)
       throws -> IWICBitmapDecoder {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
+      var pIDecoder: UnsafeMutablePointer<WinSDK.IWICBitmapDecoder>?
+      let hr: HRESULT
+      if var guidVendor = guidVendor {
+        hr = pThis.pointee.lpVtbl.pointee.CreateDecoder(pThis, guidContainerFormat,
+                                                        &guidVendor, &pIDecoder)
+      } else {
+        hr = pThis.pointee.lpVtbl.pointee.CreateDecoder(pThis, guidContainerFormat,
+                                                        nil, &pIDecoder)
+      }
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICBitmapDecoder(pUnk: pIDecoder)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICImagingFactory.self, capacity: 1)
-
-    var pIDecoder: UnsafeMutablePointer<WinSDK.IWICBitmapDecoder>?
-    let hr: HRESULT
-    if var guidVendor = guidVendor {
-      hr = pThis.pointee.lpVtbl.pointee.CreateDecoder(pThis, guidContainerFormat,
-                                                      &guidVendor, &pIDecoder)
-    } else {
-      hr = pThis.pointee.lpVtbl.pointee.CreateDecoder(pThis, guidContainerFormat,
-                                                      nil, &pIDecoder)
-    }
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICBitmapDecoder(pUnk: pIDecoder)
   }
 
   public func CreateDecoderFromFileHandle(_ hFile: ULONG_PTR,
                                           _ guidVendor: GUID?,
                                           _ metadataOptions: WICDecodeOptions)
       throws -> IWICBitmapDecoder {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
+      var pIDecoder: UnsafeMutablePointer<WinSDK.IWICBitmapDecoder>?
+      let hr: HRESULT
+      if var guidVendor = guidVendor {
+        hr = pThis.pointee.lpVtbl.pointee
+                .CreateDecoderFromFileHandle(pThis, hFile, &guidVendor,
+                                             metadataOptions, &pIDecoder)
+      } else {
+        hr = pThis.pointee.lpVtbl.pointee
+                .CreateDecoderFromFileHandle(pThis, hFile, nil, metadataOptions,
+                                             &pIDecoder)
+      }
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICBitmapDecoder(pUnk: pIDecoder)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICImagingFactory.self, capacity: 1)
-
-    var pIDecoder: UnsafeMutablePointer<WinSDK.IWICBitmapDecoder>?
-    let hr: HRESULT
-    if var guidVendor = guidVendor {
-      hr = pThis.pointee.lpVtbl.pointee
-              .CreateDecoderFromFileHandle(pThis, hFile, &guidVendor,
-                                           metadataOptions, &pIDecoder)
-    } else {
-      hr = pThis.pointee.lpVtbl.pointee
-              .CreateDecoderFromFileHandle(pThis, hFile, nil, metadataOptions,
-                                           &pIDecoder)
-    }
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICBitmapDecoder(pUnk: pIDecoder)
   }
 
   public func CreateDecoderFromFilename(_ szFileName: String,
@@ -265,190 +220,161 @@ public class IWICImagingFactory: IUnknown {
                                         _ dwDesiredAccess: DWORD,
                                         _ metadataOptions: WICDecodeOptions)
       throws -> IWICBitmapDecoder {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICImagingFactory.self, capacity: 1)
-
-    var pIDecoder: UnsafeMutablePointer<WinSDK.IWICBitmapDecoder>?
-    let hr: HRESULT
-    if var guidVendor = guidVendor {
-      hr = szFileName.withCString(encodedAs: UTF16.self) {
-        pThis.pointee.lpVtbl.pointee.CreateDecoderFromFilename(pThis, $0,
-                                                               &guidVendor,
-                                                               dwDesiredAccess,
-                                                               metadataOptions,
-                                                               &pIDecoder)
+    return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
+      var pIDecoder: UnsafeMutablePointer<WinSDK.IWICBitmapDecoder>?
+      let hr: HRESULT
+      if var guidVendor = guidVendor {
+        hr = szFileName.withCString(encodedAs: UTF16.self) {
+          pThis.pointee.lpVtbl.pointee.CreateDecoderFromFilename(pThis, $0,
+                                                                 &guidVendor,
+                                                                 dwDesiredAccess,
+                                                                 metadataOptions,
+                                                                 &pIDecoder)
+        }
+      } else {
+        hr = szFileName.withCString(encodedAs: UTF16.self) {
+          pThis.pointee.lpVtbl.pointee.CreateDecoderFromFilename(pThis, $0, nil,
+                                                                 dwDesiredAccess,
+                                                                 metadataOptions,
+                                                                 &pIDecoder)
+        }
       }
-    } else {
-      hr = szFileName.withCString(encodedAs: UTF16.self) {
-        pThis.pointee.lpVtbl.pointee.CreateDecoderFromFilename(pThis, $0, nil,
-                                                               dwDesiredAccess,
-                                                               metadataOptions,
-                                                               &pIDecoder)
-      }
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICBitmapDecoder(pUnk: pIDecoder)
     }
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICBitmapDecoder(pUnk: pIDecoder)
   }
 
   public func CreateDecoderFromStream(_ pIStream: IStream, _ guidVendor: GUID?,
                                       _ metadataOptions: WICDecodeOptions)
       throws -> IWICBitmapDecoder {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
+      var pIDecoder: UnsafeMutablePointer<WinSDK.IWICBitmapDecoder>?
+      let hr: HRESULT
+      if var guidVendor = guidVendor {
+        hr = pThis.pointee.lpVtbl.pointee
+                .CreateDecoderFromStream(pThis, RawPointer(pIStream), &guidVendor,
+                                         metadataOptions, &pIDecoder)
+      } else {
+        hr = pThis.pointee.lpVtbl.pointee
+                .CreateDecoderFromStream(pThis, RawPointer(pIStream), nil,
+                                         metadataOptions, &pIDecoder)
+      }
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICBitmapDecoder(pUnk: pIDecoder)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICImagingFactory.self, capacity: 1)
-
-    var pIDecoder: UnsafeMutablePointer<WinSDK.IWICBitmapDecoder>?
-    let hr: HRESULT
-    if var guidVendor = guidVendor {
-      hr = pThis.pointee.lpVtbl.pointee
-              .CreateDecoderFromStream(pThis, RawPointer(pIStream), &guidVendor,
-                                       metadataOptions, &pIDecoder)
-    } else {
-      hr = pThis.pointee.lpVtbl.pointee
-              .CreateDecoderFromStream(pThis, RawPointer(pIStream), nil,
-                                       metadataOptions, &pIDecoder)
-    }
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICBitmapDecoder(pUnk: pIDecoder)
   }
 
   public func CreateEncoder(_ guidContainerFormat: REFGUID,
                             _ guidVendor: GUID?) throws -> IWICBitmapEncoder {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
+      var pIEncoder: UnsafeMutablePointer<WinSDK.IWICBitmapEncoder>?
+      let hr: HRESULT
+      if var guidVendor = guidVendor {
+        hr = pThis.pointee.lpVtbl.pointee.CreateEncoder(pThis, guidContainerFormat,
+                                                        &guidVendor, &pIEncoder)
+      } else {
+        hr = pThis.pointee.lpVtbl.pointee.CreateEncoder(pThis, guidContainerFormat,
+                                                        nil, &pIEncoder)
+      }
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICBitmapEncoder(pUnk: pIEncoder)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICImagingFactory.self, capacity: 1)
-
-    var pIEncoder: UnsafeMutablePointer<WinSDK.IWICBitmapEncoder>?
-    let hr: HRESULT
-    if var guidVendor = guidVendor {
-      hr = pThis.pointee.lpVtbl.pointee.CreateEncoder(pThis, guidContainerFormat,
-                                                      &guidVendor, &pIEncoder)
-    } else {
-      hr = pThis.pointee.lpVtbl.pointee.CreateEncoder(pThis, guidContainerFormat,
-                                                      nil, &pIEncoder)
-    }
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICBitmapEncoder(pUnk: pIEncoder)
   }
 
   public func CreateFastMetadataEncoderFromDecoder(_ pIDecoder: IWICBitmapDecoder)
       throws -> IWICFastMetadataEncoder {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
+      var pIFastEncoder: UnsafeMutablePointer<WinSDK.IWICFastMetadataEncoder>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee
+              .CreateFastMetadataEncoderFromDecoder(pThis, RawPointer(pIDecoder),
+                                                    &pIFastEncoder)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICFastMetadataEncoder(pUnk: pIFastEncoder)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICImagingFactory.self, capacity: 1)
-
-    var pIFastEncoder: UnsafeMutablePointer<WinSDK.IWICFastMetadataEncoder>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee
-            .CreateFastMetadataEncoderFromDecoder(pThis, RawPointer(pIDecoder),
-                                                  &pIFastEncoder)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICFastMetadataEncoder(pUnk: pIFastEncoder)
   }
 
   public func CreateFastMetadataEncoderFromFrameDecode(_ pIFrameDecoder: IWICBitmapFrameDecode)
       throws -> IWICFastMetadataEncoder {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
+      var pIFastEncoder: UnsafeMutablePointer<WinSDK.IWICFastMetadataEncoder>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee
+              .CreateFastMetadataEncoderFromFrameDecode(pThis,
+                                                        RawPointer(pIFrameDecoder),
+                                                        &pIFastEncoder)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICFastMetadataEncoder(pUnk: pIFastEncoder)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICImagingFactory.self, capacity: 1)
-
-    var pIFastEncoder: UnsafeMutablePointer<WinSDK.IWICFastMetadataEncoder>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee
-            .CreateFastMetadataEncoderFromFrameDecode(pThis,
-                                                      RawPointer(pIFrameDecoder),
-                                                      &pIFastEncoder)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICFastMetadataEncoder(pUnk: pIFastEncoder)
   }
 
   public func CreateFormatConverter() throws -> IWICFormatConverter {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
+      var pIFormatConverter: UnsafeMutablePointer<WinSDK.IWICFormatConverter>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.CreateFormatConverter(pThis,
+                                                             &pIFormatConverter)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICFormatConverter(pUnk: pIFormatConverter)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICImagingFactory.self, capacity: 1)
-
-    var pIFormatConverter: UnsafeMutablePointer<WinSDK.IWICFormatConverter>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.CreateFormatConverter(pThis, &pIFormatConverter)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICFormatConverter(pUnk: pIFormatConverter)
   }
 
   public func CreatePalette() throws -> IWICPalette {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
+      var pIPalette: UnsafeMutablePointer<WinSDK.IWICPalette>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.CreatePalette(pThis, &pIPalette)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICPalette(pUnk: pIPalette)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICImagingFactory.self, capacity: 1)
-
-    var pIPalette: UnsafeMutablePointer<WinSDK.IWICPalette>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.CreatePalette(pThis, &pIPalette)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICPalette(pUnk: pIPalette)
   }
 
   public func CreateQueryWriter(_ guidMetadataFormat: REFGUID,
                                 _ guidVendor: GUID?)
       throws -> IWICMetadataQueryWriter {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
+      var pIQueryWriter: UnsafeMutablePointer<WinSDK.IWICMetadataQueryWriter>?
+      let hr: HRESULT
+      if var guidVendor = guidVendor {
+        hr = pThis.pointee.lpVtbl.pointee
+                .CreateQueryWriter(pThis, guidMetadataFormat, &guidVendor,
+                                  &pIQueryWriter)
+      } else {
+        hr = pThis.pointee.lpVtbl.pointee
+                .CreateQueryWriter(pThis, guidMetadataFormat, nil, &pIQueryWriter)
+      }
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICMetadataQueryWriter(pUnk: pIQueryWriter)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICImagingFactory.self, capacity: 1)
-
-    var pIQueryWriter: UnsafeMutablePointer<WinSDK.IWICMetadataQueryWriter>?
-    let hr: HRESULT
-    if var guidVendor = guidVendor {
-      hr = pThis.pointee.lpVtbl.pointee
-              .CreateQueryWriter(pThis, guidMetadataFormat, &guidVendor,
-                                 &pIQueryWriter)
-    } else {
-      hr = pThis.pointee.lpVtbl.pointee
-              .CreateQueryWriter(pThis, guidMetadataFormat, nil, &pIQueryWriter)
-    }
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICMetadataQueryWriter(pUnk: pIQueryWriter)
   }
 
   public func CreateQueryWriterFromReader(_ pIQueryReader: IWICMetadataQueryReader,
                                           _ guidVendor: GUID?)
       throws -> IWICMetadataQueryWriter {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
+      var pIQueryWriter: UnsafeMutablePointer<WinSDK.IWICMetadataQueryWriter>?
+      let hr: HRESULT
+      if var guidVendor = guidVendor {
+        hr = pThis.pointee.lpVtbl.pointee
+                .CreateQueryWriterFromReader(pThis, RawPointer(pIQueryReader),
+                                             &guidVendor, &pIQueryWriter)
+      } else {
+        hr = pThis.pointee.lpVtbl.pointee
+                .CreateQueryWriterFromReader(pThis, RawPointer(pIQueryReader),
+                                             nil, &pIQueryWriter)
+      }
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICMetadataQueryWriter(pUnk: pIQueryWriter)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICImagingFactory.self, capacity: 1)
-
-    var pIQueryWriter: UnsafeMutablePointer<WinSDK.IWICMetadataQueryWriter>?
-    let hr: HRESULT
-    if var guidVendor = guidVendor {
-      hr = pThis.pointee.lpVtbl.pointee
-              .CreateQueryWriterFromReader(pThis, RawPointer(pIQueryReader),
-                                           &guidVendor, &pIQueryWriter)
-    } else {
-      hr = pThis.pointee.lpVtbl.pointee
-              .CreateQueryWriterFromReader(pThis, RawPointer(pIQueryReader),
-                                           nil, &pIQueryWriter)
-    }
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICMetadataQueryWriter(pUnk: pIQueryWriter)
   }
 
   public func CreateStream() throws -> IWICStream {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
+      var pIWICStream: UnsafeMutablePointer<WinSDK.IWICStream>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.CreateStream(pThis, &pIWICStream)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IWICStream(pUnk: pIWICStream)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICImagingFactory.self, capacity: 1)
-
-    var pIWICStream: UnsafeMutablePointer<WinSDK.IWICStream>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.CreateStream(pThis, &pIWICStream)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IWICStream(pUnk: pIWICStream)
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICMetadataQueryReader.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICMetadataQueryReader.swift
@@ -11,70 +11,55 @@ public class IWICMetadataQueryReader: IUnknown {
   override public class var IID: IID { IID_IWICMetadataQueryReader }
 
   public func GetContainerFormat() throws -> GUID {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICMetadataQueryReader.self) { pThis in
+      var guidContainerFormat: GUID = GUID()
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetContainerFormat(pThis,
+                                                          &guidContainerFormat)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return guidContainerFormat
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IWICMetadataQueryReader.self, capacity: 1)
-
-    var guidContainerFormat: GUID = GUID()
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetContainerFormat(pThis,
-                                                        &guidContainerFormat)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return guidContainerFormat
   }
 
   public func GetEnumerator() throws -> IEnumString {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICMetadataQueryReader.self) { pThis in
+      var pIEnumString: UnsafeMutablePointer<WinSDK.IEnumString>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetEnumerator(pThis, &pIEnumString)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return IEnumString(pUnk: pIEnumString)
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IWICMetadataQueryReader.self, capacity: 1)
-
-    var pIEnumString: UnsafeMutablePointer<WinSDK.IEnumString>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetEnumerator(pThis, &pIEnumString)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return IEnumString(pUnk: pIEnumString)
   }
 
   public func GetLocation() throws -> String {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IWICMetadataQueryReader.self, capacity: 1)
-
-    var cchActualLength: UINT = UINT(0)
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetLocation(pThis, 0, nil, &cchActualLength)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-
-    let buffer: [WCHAR] =
-        try Array<WCHAR>(unsafeUninitializedCapacity: Int(cchActualLength)) {
+    return try perform(as: WinSDK.IWICMetadataQueryReader.self) { pThis in
+      var cchActualLength: UINT = UINT(0)
       let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetLocation(pThis, UINT($0.count),
-                                                   $0.baseAddress,
+          pThis.pointee.lpVtbl.pointee.GetLocation(pThis, 0, nil,
                                                    &cchActualLength)
       guard hr == S_OK else { throw COMError(hr: hr) }
-      $1 = Int(cchActualLength)
+
+      let buffer: [WCHAR] =
+          try Array<WCHAR>(unsafeUninitializedCapacity: Int(cchActualLength)) {
+        let hr: HRESULT =
+            pThis.pointee.lpVtbl.pointee.GetLocation(pThis, UINT($0.count),
+                                                    $0.baseAddress,
+                                                    &cchActualLength)
+        guard hr == S_OK else { throw COMError(hr: hr) }
+        $1 = Int(cchActualLength)
+      }
+      return String(decoding: buffer, as: UTF16.self)
     }
-    return String(decoding: buffer, as: UTF16.self)
   }
 
   public func GetMetadataByName(_ szName: String) throws -> PROPVARIANT {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICMetadataQueryReader.self) { pThis in
+      var varValue: PROPVARIANT = PROPVARIANT()
+      let hr: HRESULT = szName.withCString(encodedAs: UTF16.self) {
+        pThis.pointee.lpVtbl.pointee.GetMetadataByName(pThis, $0, &varValue)
+      }
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return varValue
     }
-    let pThis =
-        pUnk.bindMemory(to: WinSDK.IWICMetadataQueryReader.self, capacity: 1)
-
-    var varValue: PROPVARIANT = PROPVARIANT()
-    let hr: HRESULT = szName.withCString(encodedAs: UTF16.self) {
-      pThis.pointee.lpVtbl.pointee.GetMetadataByName(pThis, $0, &varValue)
-    }
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return varValue
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICMetadataQueryWriter.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICMetadataQueryWriter.swift
@@ -11,27 +11,21 @@ public class IWICMetadataQueryWriter: IWICMetadataQueryReader {
   override public class var IID: IID { IID_IWICMetadataQueryWriter }
 
   public func RemoveMetadataByName(_ szName: String) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICMetadataQueryWriter.self) { pThis in
+      let hr: HRESULT = szName.withCString(encodedAs: UTF16.self) {
+        pThis.pointee.lpVtbl.pointee.RemoveMetadataByName(pThis, $0)
+      }
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICMetadataQueryWriter.self, capacity: 1)
-
-    let hr: HRESULT = szName.withCString(encodedAs: UTF16.self) {
-      pThis.pointee.lpVtbl.pointee.RemoveMetadataByName(pThis, $0)
-    }
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func SetMetadataByName(_ szName: String, _ varValue: PROPVARIANT) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICMetadataQueryWriter.self) { pThis in
+      var varValue = varValue
+      let hr: HRESULT = szName.withCString(encodedAs: UTF16.self) {
+        pThis.pointee.lpVtbl.pointee.SetMetadataByName(pThis, $0, &varValue)
+      }
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICMetadataQueryWriter.self, capacity: 1)
-
-    var varValue = varValue
-    let hr: HRESULT = szName.withCString(encodedAs: UTF16.self) {
-      pThis.pointee.lpVtbl.pointee.SetMetadataByName(pThis, $0, &varValue)
-    }
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICPalette.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICPalette.swift
@@ -11,138 +11,108 @@ public class IWICPalette: IUnknown {
   override public class var IID: IID { IID_IWICPalette }
 
   public func GetColorCount() throws -> UINT {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICPalette.self) { pThis in
+      var cCount: UINT = UINT(0)
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetColorCount(pThis, &cCount)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return cCount
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICPalette.self, capacity: 1)
-
-    var cCount: UINT = UINT(0)
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetColorCount(pThis, &cCount)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return cCount
   }
 
   public func GetColors() throws -> [WICColor] {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICPalette.self, capacity: 1)
-
-    let cCount: UINT = try GetColorCount()
-    return try Array<WICColor>(unsafeUninitializedCapacity: Int(cCount)) {
-      var cActualColors: UINT = UINT(0)
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetColors(pThis, cCount, $0.baseAddress,
-                                                 &cActualColors)
-      guard hr == S_OK else { throw COMError(hr: hr) }
-      $1 = Int(cActualColors)
+    return try perform(as: WinSDK.IWICPalette.self) { pThis in
+      let cCount: UINT = try GetColorCount()
+      return try Array<WICColor>(unsafeUninitializedCapacity: Int(cCount)) {
+        var cActualColors: UINT = UINT(0)
+        let hr: HRESULT =
+            pThis.pointee.lpVtbl.pointee.GetColors(pThis, cCount, $0.baseAddress,
+                                                  &cActualColors)
+        guard hr == S_OK else { throw COMError(hr: hr) }
+        $1 = Int(cActualColors)
+      }
     }
   }
 
   public func GetType() throws -> WICBitmapPaletteType {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICPalette.self) { pThis in
+      var ePaletteType: WICBitmapPaletteType = WICBitmapPaletteType(0)
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetType(pThis, &ePaletteType)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return ePaletteType
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICPalette.self, capacity: 1)
-
-    var ePaletteType: WICBitmapPaletteType = WICBitmapPaletteType(0)
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetType(pThis, &ePaletteType)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return ePaletteType
   }
 
   public func HasAlpha() throws -> Bool {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICPalette.self) { pThis in
+      var fHasAlpha: WindowsBool = false
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.HasAlpha(pThis, &fHasAlpha)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return fHasAlpha == true
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICPalette.self, capacity: 1)
-
-    var fHasAlpha: WindowsBool = false
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.HasAlpha(pThis, &fHasAlpha)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return fHasAlpha == true
   }
 
   public func InitializeCustom(_ pColors: [WICColor]) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICPalette.self) { pThis in
+      var pColors: [WICColor] = pColors
+      let hr: HRESULT = pColors.withUnsafeMutableBufferPointer {
+        pThis.pointee.lpVtbl.pointee.InitializeCustom(pThis, $0.baseAddress,
+                                                      UINT($0.count))
+      }
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICPalette.self, capacity: 1)
-
-    var pColors: [WICColor] = pColors
-    let hr: HRESULT = pColors.withUnsafeMutableBufferPointer {
-      pThis.pointee.lpVtbl.pointee.InitializeCustom(pThis, $0.baseAddress,
-                                                    UINT($0.count))
-    }
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func InitializeFromBitmap(_ pISurface: IWICBitmapSource,
                                    _ cCount: UINT,
                                    _ fAddTransparentColor: WindowsBool) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICPalette.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.InitializeFromBitmap(pThis,
+                                                            RawPointer(pISurface),
+                                                            cCount,
+                                                            fAddTransparentColor)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICPalette.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.InitializeFromBitmap(pThis,
-                                                          RawPointer(pISurface),
-                                                          cCount,
-                                                          fAddTransparentColor)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func InitializeFromPalette(_ pIPalette: IWICPalette) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICPalette.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.InitializeFromPalette(pThis,
+                                                            RawPointer(pIPalette))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICPalette.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.InitializeFromPalette(pThis,
-                                                           RawPointer(pIPalette))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func InitializePredefined(_ ePaletteType: WICBitmapPaletteType,
                                    _ fAddTransparentColor: WindowsBool) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICPalette.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.InitializePredefined(pThis, ePaletteType,
+                                                            fAddTransparentColor)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICPalette.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.InitializePredefined(pThis, ePaletteType,
-                                                          fAddTransparentColor)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func IsBlackWhite() throws -> Bool {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICPalette.self) { pThis in
+      var fIsBlackWhite: WindowsBool = false
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.IsBlackWhite(pThis, &fIsBlackWhite)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return fIsBlackWhite == true
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICPalette.self, capacity: 1)
-
-    var fIsBlackWhite: WindowsBool = false
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.IsBlackWhite(pThis, &fIsBlackWhite)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return fIsBlackWhite == true
   }
 
   public func IsGrayscale() throws -> Bool {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICPalette.self) { pThis in
+      var fIsGrayscale: WindowsBool = false
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.IsGrayscale(pThis, &fIsGrayscale)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return fIsGrayscale == true
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICPalette.self, capacity: 1)
-
-    var fIsGrayscale: WindowsBool = false
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.IsGrayscale(pThis, &fIsGrayscale)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return fIsGrayscale == true
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICStream.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICStream.swift
@@ -12,56 +12,44 @@ public class IWICStream: IStream {
 
   public func InitializeFromFilename(_ szFileName: String,
                                      _ dwDesiredAccess: DWORD) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICStream.self) { pThis in
+      let hr: HRESULT = szFileName.withCString(encodedAs: UTF16.self) {
+        pThis.pointee.lpVtbl.pointee.InitializeFromFilename(pThis, $0,
+                                                            dwDesiredAccess)
+      }
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICStream.self, capacity: 1)
-
-    let hr: HRESULT = szFileName.withCString(encodedAs: UTF16.self) {
-      pThis.pointee.lpVtbl.pointee.InitializeFromFilename(pThis, $0,
-                                                          dwDesiredAccess)
-    }
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func InitializeFromIStream(_ pIStream: IStream) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICStream.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.InitializeFromIStream(pThis,
+                                                            RawPointer(pIStream))
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICStream.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.InitializeFromIStream(pThis,
-                                                           RawPointer(pIStream))
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func InitializeFromIStreamRegion(_ pIStream: IStream,
                                           _ ulOffset: ULARGE_INTEGER,
                                           _ ulMaxSize: ULARGE_INTEGER) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICStream.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.InitializeFromIStreamRegion(pThis,
+                                                                  RawPointer(pIStream),
+                                                                  ulOffset,
+                                                                  ulMaxSize)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICStream.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.InitializeFromIStreamRegion(pThis,
-                                                                 RawPointer(pIStream),
-                                                                 ulOffset,
-                                                                 ulMaxSize)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 
   public func InitializeFromMemory(_ pbBuffer: UnsafeMutablePointer<BYTE>?,
                                    _ cbBufferSize: DWORD) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.IWICStream.self) { pThis in
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.InitializeFromMemory(pThis, pbBuffer,
+                                                            cbBufferSize)
+      guard hr == S_OK else { throw COMError(hr: hr) }
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.IWICStream.self, capacity: 1)
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.InitializeFromMemory(pThis, pbBuffer,
-                                                          cbBufferSize)
-    guard hr == S_OK else { throw COMError(hr: hr) }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/ITypeComp.swift
+++ b/Sources/SwiftCOM/Interfaces/ITypeComp.swift
@@ -17,37 +17,31 @@ open class ITypeComp: IUnknown {
   /// contained in a type library.
   public func Bind(_ name: String, _ lHashVal: ULONG, _ wFlags: WORD)
       throws -> (ITypeInfo, DESCKIND, BINDPTR) {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ITypeComp.self) { pThis in
+      var szName: [OLECHAR] = Array<OLECHAR>(from: name)
+      var pTInfo: UnsafeMutablePointer<WinSDK.ITypeInfo>?
+      var DescKind: DESCKIND = DESCKIND_MAX
+      var BindPtr: BINDPTR = BINDPTR()
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.Bind(pThis, &szName, lHashVal, wFlags,
+                                            &pTInfo, &DescKind, &BindPtr)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return (ITypeInfo(pUnk: pTInfo), DescKind, BindPtr)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ITypeComp.self, capacity: 1)
-
-    var szName: [OLECHAR] = Array<OLECHAR>(from: name)
-    var pTInfo: UnsafeMutablePointer<WinSDK.ITypeInfo>?
-    var DescKind: DESCKIND = DESCKIND_MAX
-    var BindPtr: BINDPTR = BINDPTR()
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.Bind(pThis, &szName, lHashVal, wFlags,
-                                          &pTInfo, &DescKind, &BindPtr)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return (ITypeInfo(pUnk: pTInfo), DescKind, BindPtr)
   }
 
   /// Binds to the type descriptions contained within a type library.
   public func BindType(_ name: String, lHashVal: ULONG)
       throws -> (ITypeInfo, ITypeComp) {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ITypeComp.self) { pThis in
+      var szName: [OLECHAR] = Array<OLECHAR>(from: name)
+      var pTInfo: UnsafeMutablePointer<WinSDK.ITypeInfo>?
+      var pTComp: UnsafeMutablePointer<WinSDK.ITypeComp>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.BindType(pThis, &szName, lHashVal,
+                                                &pTInfo, &pTComp)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return (ITypeInfo(pUnk: pTInfo), ITypeComp(pUnk: pTComp))
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ITypeComp.self, capacity: 1)
-
-    var szName: [OLECHAR] = Array<OLECHAR>(from: name)
-    var pTInfo: UnsafeMutablePointer<WinSDK.ITypeInfo>?
-    var pTComp: UnsafeMutablePointer<WinSDK.ITypeComp>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.BindType(pThis, &szName, lHashVal,
-                                              &pTInfo, &pTComp)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return (ITypeInfo(pUnk: pTInfo), ITypeComp(pUnk: pTComp))
   }
 }

--- a/Sources/SwiftCOM/Interfaces/ITypeInfo.swift
+++ b/Sources/SwiftCOM/Interfaces/ITypeInfo.swift
@@ -14,60 +14,48 @@ open class ITypeInfo: IUnknown {
   /// Retrieves a `TYPEATTR` structure that contains the attributes of the type
   /// description.
   public func GetTypeAttr() throws -> UnsafeMutablePointer<TYPEATTR> {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ITypeInfo.self) { pThis in
+      var pTypeAttr: UnsafeMutablePointer<TYPEATTR>?
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetTypeAttr(pThis, &pTypeAttr)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return pTypeAttr!
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ITypeInfo.self, capacity: 1)
-
-    var pTypeAttr: UnsafeMutablePointer<TYPEATTR>?
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetTypeAttr(pThis, &pTypeAttr)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return pTypeAttr!
   }
 
   /// Retrieves the ITypeComp interface for the type description, which enables a
   /// client compiler to bind to the type description's members.
   public func GetTypeComp() throws -> ITypeComp {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ITypeInfo.self) { pThis in
+      var pTComp: UnsafeMutablePointer<WinSDK.ITypeComp>?
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetTypeComp(pThis, &pTComp)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return ITypeComp(pUnk: pTComp)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ITypeInfo.self, capacity: 1)
-
-    var pTComp: UnsafeMutablePointer<WinSDK.ITypeComp>?
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetTypeComp(pThis, &pTComp)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return ITypeComp(pUnk: pTComp)
   }
 
   // TODO(compnerd) create a managed copy of FUNCDESC
   /// Retrieves the `FUNCDESC` structure that contains information about a
   /// specified function.
   public func GetFuncDesc(_ index: UINT) throws -> UnsafeMutablePointer<FUNCDESC> {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ITypeInfo.self) { pThis in
+      var pFuncDesc: UnsafeMutablePointer<FUNCDESC>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetFuncDesc(pThis, index, &pFuncDesc)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return pFuncDesc!
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ITypeInfo.self, capacity: 1)
-
-    var pFuncDesc: UnsafeMutablePointer<FUNCDESC>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetFuncDesc(pThis, index, &pFuncDesc)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return pFuncDesc!
   }
 
   // TODO(compnerd) create a managed copy of VARDESC
   /// Retrieves a `VARDESC` structure that describes the specified variable.
   public func GetVarDesc(_ index: UINT) throws -> UnsafeMutablePointer<VARDESC> {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ITypeInfo.self) { pThis in
+      var pVarDesc: UnsafeMutablePointer<VARDESC>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetVarDesc(pThis, index, &pVarDesc)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return pVarDesc!
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ITypeInfo.self, capacity: 1)
-
-    var pVarDesc: UnsafeMutablePointer<VARDESC>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetVarDesc(pThis, index, &pVarDesc)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return pVarDesc!
   }
 
   /// Retrieves the variable with the specified member ID or the name of the
@@ -75,27 +63,24 @@ open class ITypeInfo: IUnknown {
   /// function ID.
   public func GetNames(_ member: MEMBERID, count cMaxNames: UINT)
       throws -> [String] {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ITypeInfo.self) { pThis in
+      let rgBstrNames: UnsafeMutablePointer<BSTR?> =
+          UnsafeMutablePointer.allocate(capacity: Int(cMaxNames) + 1)
+      defer { rgBstrNames.deallocate() }
+
+      var cNames: UINT = 0
+      let hr: HRESULT =
+        pThis.pointee.lpVtbl.pointee.GetNames(pThis, member, rgBstrNames,
+                                              cMaxNames + 1, &cNames)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+
+      var names: [String] = Array<String>()
+      names.reserveCapacity(Int(cNames))
+      for i in 0 ..< cNames {
+        names.append(String(from: rgBstrNames[Int(i)]!))
+      }
+      return names
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ITypeInfo.self, capacity: 1)
-
-    let rgBstrNames: UnsafeMutablePointer<BSTR?> =
-        UnsafeMutablePointer.allocate(capacity: Int(cMaxNames) + 1)
-    defer { rgBstrNames.deallocate() }
-
-    var cNames: UINT = 0
-    let hr: HRESULT =
-      pThis.pointee.lpVtbl.pointee.GetNames(pThis, member, rgBstrNames,
-                                            cMaxNames + 1, &cNames)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-
-    var names: [String] = Array<String>()
-    names.reserveCapacity(Int(cNames))
-    for i in 0 ..< cNames {
-      names.append(String(from: rgBstrNames[Int(i)]!))
-    }
-    return names
   }
 
   /// If a type description describes a COM class, it retrieves the type
@@ -103,73 +88,61 @@ open class ITypeInfo: IUnknown {
   /// GetRefTypeOfImplType returns the type information for inherited interfaces,
   /// if any exist.
   public func GetRefTypeOfImplType(_ index: UINT) throws -> HREFTYPE {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ITypeInfo.self) { pThis in
+      var pRefType: HREFTYPE = HREFTYPE()
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetRefTypeOfImplType(pThis, index, &pRefType)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return pRefType
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ITypeInfo.self, capacity: 1)
-
-    var pRefType: HREFTYPE = HREFTYPE()
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetRefTypeOfImplType(pThis, index, &pRefType)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return pRefType
   }
 
   /// Retrieves the `IMPLTYPEFLAGS` enumeration for one implemented interface or
   /// base interface in a type description.
   public func GetImplTypeFlags(_ index: UINT) throws -> INT {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ITypeInfo.self) { pThis in
+      var ImplTypeFlags: INT = INT()
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetImplTypeFlags(pThis, index,
+                                                        &ImplTypeFlags)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return ImplTypeFlags
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ITypeInfo.self, capacity: 1)
-
-    var ImplTypeFlags: INT = INT()
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetImplTypeFlags(pThis, index,
-                                                      &ImplTypeFlags)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return ImplTypeFlags
   }
 
   /// Maps between member names and member IDs, and parameter names and parameter
   /// IDs.
   public func GetIDsOfNames(_ names: [String]) throws -> [MEMBERID] {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis = pUnk.bindMemory(to: WinSDK.ITypeInfo.self, capacity: 1)
+    return try perform(as: WinSDK.ITypeInfo.self) { pThis in
+      var rgszNames: [LPOLESTR?] = names.map {
+        $0.withCString(encodedAs: UTF16.self, _wcsdup)
+      }
+      defer { rgszNames.forEach { free($0) } }
 
-    var rgszNames: [LPOLESTR?] = names.map {
-      $0.withCString(encodedAs: UTF16.self, _wcsdup)
+      var MemId: [MEMBERID] =
+          Array<MEMBERID>(repeating: MEMBERID_NIL, count: names.count)
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetIDsOfNames(pThis, &rgszNames,
+                                                    UINT(names.count), &MemId)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return MemId
     }
-    defer { rgszNames.forEach { free($0) } }
-
-    var MemId: [MEMBERID] =
-        Array<MEMBERID>(repeating: MEMBERID_NIL, count: names.count)
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetIDsOfNames(pThis, &rgszNames,
-                                                   UINT(names.count), &MemId)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return MemId
   }
 
   public func Invoke(_ pInstance: UnsafeMutableRawPointer, _ member: MEMBERID,
                      _ wFlags: WORD, _ pDispParams: inout [DISPPARAMS])
       throws -> (result: VARIANT, exception: EXCEPINFO, error: UINT) {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ITypeInfo.self) { pThis in
+      var VarResult: VARIANT = VARIANT()
+      var ExcepInfo: EXCEPINFO = EXCEPINFO()
+      var uArgError: UINT = 0
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.Invoke(pThis, pInstance, member, wFlags,
+                                              &pDispParams, &VarResult,
+                                              &ExcepInfo, &uArgError)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return (result: VarResult, exception: ExcepInfo, error: uArgError)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ITypeInfo.self, capacity: 1)
-
-    var VarResult: VARIANT = VARIANT()
-    var ExcepInfo: EXCEPINFO = EXCEPINFO()
-    var uArgError: UINT = 0
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.Invoke(pThis, pInstance, member, wFlags,
-                                            &pDispParams, &VarResult, &ExcepInfo,
-                                            &uArgError)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return (result: VarResult, exception: ExcepInfo, error: uArgError)
   }
 
   /// Retrieves the documentation string, the complete Help file name and path,
@@ -177,164 +150,135 @@ open class ITypeInfo: IUnknown {
   public func GetDocumentation(_ member: MEMBERID)
       throws -> (name: String, docstring: String,
                  help: (context: DWORD, file: String)) {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis = pUnk.bindMemory(to: WinSDK.ITypeInfo.self, capacity: 1)
+    return try perform(as: WinSDK.ITypeInfo.self) { pThis in
+      var bstrName: BSTR?
+      var bstrDocString: BSTR?
+      var dwHelpContext: DWORD = DWORD.max
+      var bstrHelpFile: BSTR?
 
-    var bstrName: BSTR?
-    var bstrDocString: BSTR?
-    var dwHelpContext: DWORD = DWORD.max
-    var bstrHelpFile: BSTR?
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee
-        .GetDocumentation(pThis, member, &bstrName, &bstrDocString,
-                          &dwHelpContext, &bstrHelpFile)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    defer {
-      SysFreeString(bstrName)
-      SysFreeString(bstrDocString)
-      SysFreeString(bstrHelpFile)
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee
+          .GetDocumentation(pThis, member, &bstrName, &bstrDocString,
+                            &dwHelpContext, &bstrHelpFile)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      defer {
+        SysFreeString(bstrName)
+        SysFreeString(bstrDocString)
+        SysFreeString(bstrHelpFile)
+      }
+      return (name: bstrName == nil ? "" : String(from: bstrName!),
+              docstring: bstrDocString == nil ? "" : String(from: bstrDocString!),
+              help: (context: dwHelpContext,
+                     file: bstrHelpFile == nil ? "" : String(from: bstrHelpFile!)))
     }
-    return (name: bstrName == nil ? "" : String(from: bstrName!),
-            docstring: bstrDocString == nil ? "" : String(from: bstrDocString!),
-            help: (context: dwHelpContext,
-                   file: bstrHelpFile == nil ? "" : String(from: bstrHelpFile!)))
   }
 
   /// Retrieves a description or specification of an entry point for a function
   /// in a DLL.
   public func GetDllEntry(_ member: MEMBERID, _ invocation: INVOKEKIND)
       throws -> (dll: String, entry: String, ordinal: WORD) {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis = pUnk.bindMemory(to: WinSDK.ITypeInfo.self, capacity: 1)
+    return try perform(as: WinSDK.ITypeInfo.self) { pThis in
+      var BstrDllName: BSTR?
+      var BstrName: BSTR?
+      var wOrdianal: WORD = 0
 
-    var BstrDllName: BSTR?
-    var BstrName: BSTR?
-    var wOrdianal: WORD = 0
-
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetDllEntry(pThis, member, invocation,
-                                                 &BstrDllName, &BstrName,
-                                                 &wOrdianal)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    defer {
-      SysFreeString(BstrDllName)
-      SysFreeString(BstrName)
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetDllEntry(pThis, member, invocation,
+                                                  &BstrDllName, &BstrName,
+                                                  &wOrdianal)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      defer {
+        SysFreeString(BstrDllName)
+        SysFreeString(BstrName)
+      }
+      return (dll: String(from: BstrDllName!), entry: String(from: BstrName!),
+              ordinal: wOrdianal)
     }
-    return (dll: String(from: BstrDllName!), entry: String(from: BstrName!),
-            ordinal: wOrdianal)
   }
 
   /// If a type description references other type descriptions, it retrieves the
   /// referenced type descriptions.
   public func GetRefTypeInfo(_ hRefType: HREFTYPE) throws -> ITypeInfo {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ITypeInfo.self) { pThis in
+      var pTInfo: UnsafeMutablePointer<WinSDK.ITypeInfo>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetRefTypeInfo(pThis, hRefType, &pTInfo)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return ITypeInfo(pUnk: pTInfo)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ITypeInfo.self, capacity: 1)
-
-    var pTInfo: UnsafeMutablePointer<WinSDK.ITypeInfo>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetRefTypeInfo(pThis, hRefType, &pTInfo)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return ITypeInfo(pUnk: pTInfo)
   }
 
   /// Retrieves the addresses of static functions or variables, such as those
   /// defined in a DLL.
   public func AddressOfMember(_ member: MEMBERID, _ invocation: INVOKEKIND)
       throws -> UnsafeMutableRawPointer {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ITypeInfo.self) { pThis in
+      var pMember: UnsafeMutableRawPointer?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.AddressOfMember(pThis, member, invocation,
+                                                      &pMember)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return pMember!
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ITypeInfo.self, capacity: 1)
-
-    var pMember: UnsafeMutableRawPointer?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.AddressOfMember(pThis, member, invocation,
-                                                     &pMember)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return pMember!
   }
 
   /// Creates a new instance of a type that describes a component object class
   /// (coclass).
   public func CreateInstance(_ pUnkOuter: IUnknown, _ riid: REFIID)
       throws -> UnsafeMutableRawPointer {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ITypeInfo.self) { pThis in
+      var pvObj: PVOID?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.CreateInstance(pThis, pUnkOuter.pUnk,
+                                                      riid, &pvObj)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return pvObj!
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ITypeInfo.self, capacity: 1)
-
-    var pvObj: PVOID?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.CreateInstance(pThis, pUnkOuter.pUnk, riid, &pvObj)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return pvObj!
   }
 
   /// Retrieves marshaling information.
   public func GetMops(_ member: MEMBERID) throws -> String {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ITypeInfo.self) { pThis in
+      var BstrMops: BSTR?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetMops(pThis, member, &BstrMops)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      defer { SysFreeString(BstrMops) }
+
+      return BstrMops == nil ? "" : String(from: BstrMops!)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ITypeInfo.self, capacity: 1)
-
-    var BstrMops: BSTR?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetMops(pThis, member, &BstrMops)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    defer { SysFreeString(BstrMops) }
-
-    return BstrMops == nil ? "" : String(from: BstrMops!)
   }
 
   /// Retrieves the containing type library and the index of the type description
   /// within that type library.
   public func GetContainingTypeLib() throws -> (typelib: ITypeLib, index: UINT) {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ITypeInfo.self) { pThis in
+      var pTLib: UnsafeMutablePointer<WinSDK.ITypeLib>?
+      var Index: UINT = 0
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetContainingTypeLib(pThis, &pTLib, &Index)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return (typelib: ITypeLib(pUnk: pTLib), index: Index)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ITypeInfo.self, capacity: 1)
-
-    var pTLib: UnsafeMutablePointer<WinSDK.ITypeLib>?
-    var Index: UINT = 0
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetContainingTypeLib(pThis, &pTLib, &Index)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return (typelib: ITypeLib(pUnk: pTLib), index: Index)
   }
 
   /// Releases a `TYPEATTR` previously returned by `GetTypeAttr`.
   public func ReleaseTypeAttr(_ pTypeAttr: UnsafeMutablePointer<TYPEATTR>) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ITypeInfo.self) { pThis in
+      pThis.pointee.lpVtbl.pointee.ReleaseTypeAttr(pThis, pTypeAttr)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ITypeInfo.self, capacity: 1)
-
-    pThis.pointee.lpVtbl.pointee.ReleaseTypeAttr(pThis, pTypeAttr)
   }
 
   /// Releases a `FUNCDESC` previously returned by `GetFuncDesc`.
   public func ReleaseFuncDesc(_ pFuncDesc: UnsafeMutablePointer<FUNCDESC>) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ITypeInfo.self) { pThis in
+      pThis.pointee.lpVtbl.pointee.ReleaseFuncDesc(pThis, pFuncDesc)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ITypeInfo.self, capacity: 1)
-
-    pThis.pointee.lpVtbl.pointee.ReleaseFuncDesc(pThis, pFuncDesc)
   }
 
   /// Releases a `VARDESC` previously returned by `GetVarDesc`.
   public func ReleaseVarDesc(_ pVarDesc: UnsafeMutablePointer<VARDESC>) throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ITypeInfo.self) { pThis in
+      pThis.pointee.lpVtbl.pointee.ReleaseVarDesc(pThis, pVarDesc)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ITypeInfo.self, capacity: 1)
-
-    pThis.pointee.lpVtbl.pointee.ReleaseVarDesc(pThis, pVarDesc)
   }
 }

--- a/Sources/SwiftCOM/Interfaces/ITypeLib.swift
+++ b/Sources/SwiftCOM/Interfaces/ITypeLib.swift
@@ -12,82 +12,66 @@ open class ITypeLib: IUnknown {
 
   /// Provides the number of type descriptions that are in a type library.
   public func GetTypeInfoCount() throws -> UINT {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ITypeLib.self) { pThis in
+      return pThis.pointee.lpVtbl.pointee.GetTypeInfoCount(pThis)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ITypeLib.self, capacity: 1)
-
-    return pThis.pointee.lpVtbl.pointee.GetTypeInfoCount(pThis)
   }
 
   /// Retrieves the specified type description in the library.
   public func GetTypeInfo(_ index: UINT) throws -> ITypeInfo {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ITypeLib.self) { pThis in
+      var info: UnsafeMutablePointer<WinSDK.ITypeInfo>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetTypeInfo(pThis, index, &info)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return ITypeInfo(pUnk: info)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ITypeLib.self, capacity: 1)
-
-    var info: UnsafeMutablePointer<WinSDK.ITypeInfo>?
-    let hr: HRESULT =
-       pThis.pointee.lpVtbl.pointee.GetTypeInfo(pThis, index, &info)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return ITypeInfo(pUnk: info)
   }
 
   /// Retrieves the type of a type description.
   public func GetTypeInfoType(_ index: UINT) throws -> TYPEKIND {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ITypeLib.self) { pThis in
+      var kind: TYPEKIND = TKIND_MAX
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetTypeInfoType(pThis, index, &kind)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return kind
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ITypeLib.self, capacity: 1)
-
-    var kind: TYPEKIND = TKIND_MAX
-    let hr: HRESULT =
-       pThis.pointee.lpVtbl.pointee.GetTypeInfoType(pThis, index, &kind)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return kind
   }
 
   /// Retrieves the type description that corresponds to the specified GUID.
   public func GetTypeInfoOfGuid(_ guid: GUID) throws -> ITypeInfo {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ITypeLib.self) { pThis in
+      var guid: GUID = guid
+      var pTinfo: UnsafeMutablePointer<WinSDK.ITypeInfo>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetTypeInfoOfGuid(pThis, &guid, &pTinfo)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return ITypeInfo(pUnk: pTinfo)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ITypeLib.self, capacity: 1)
-
-    var guid: GUID = guid
-    var pTinfo: UnsafeMutablePointer<WinSDK.ITypeInfo>?
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetTypeInfoOfGuid(pThis, &guid, &pTinfo)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return ITypeInfo(pUnk: pTinfo)
   }
 
   /// Retrieves the structure that contains the library's attributes.
   public func GetLibAttr() throws -> UnsafeMutablePointer<TLIBATTR> {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ITypeLib.self) { pThis in
+      var pTLibAttr: UnsafeMutablePointer<TLIBATTR>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetLibAttr(pThis, &pTLibAttr)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return pTLibAttr!
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ITypeLib.self, capacity: 1)
-
-    var pTLibAttr: UnsafeMutablePointer<TLIBATTR>?
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetLibAttr(pThis, &pTLibAttr)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return pTLibAttr!
   }
 
   /// Enables a client compiler to bind to the types, variables, constants, and
   /// global functions for a library.
   public func GetTypeComp() throws -> ITypeComp {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ITypeLib.self) { pThis in
+      var pTComp: UnsafeMutablePointer<WinSDK.ITypeComp>?
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.GetTypeComp(pThis, &pTComp)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return ITypeComp(pUnk: pTComp)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ITypeLib.self, capacity: 1)
-
-    var pTComp: UnsafeMutablePointer<WinSDK.ITypeComp>?
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetTypeComp(pThis, &pTComp)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return ITypeComp(pUnk: pTComp)
   }
 
   /// Retrieves the documentation string for the library, the complete Help file
@@ -96,85 +80,74 @@ open class ITypeLib: IUnknown {
   public func GetDocumentation(_ index: INT)
       throws -> (name: String, docstring: String,
                  help: (context: DWORD, file: String)) {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis = pUnk.bindMemory(to: WinSDK.ITypeLib.self, capacity: 1)
+    return try perform(as: WinSDK.ITypeLib.self) { pThis in
+      var bstrName: BSTR!
+      var bstrDocString: BSTR!
+      var dwHelpContext: DWORD = DWORD.max
+      var bstrHelpFile: BSTR!
 
-    var bstrName: BSTR!
-    var bstrDocString: BSTR!
-    var dwHelpContext: DWORD = DWORD.max
-    var bstrHelpFile: BSTR!
-
-    let hr: HRESULT = pThis.pointee.lpVtbl.pointee
-        .GetDocumentation(pThis, index, &bstrName, &bstrDocString,
-                          &dwHelpContext, &bstrHelpFile)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    defer {
-      SysFreeString(bstrName)
-      SysFreeString(bstrDocString)
-      SysFreeString(bstrHelpFile)
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee
+          .GetDocumentation(pThis, index, &bstrName, &bstrDocString,
+                            &dwHelpContext, &bstrHelpFile)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      defer {
+        SysFreeString(bstrName)
+        SysFreeString(bstrDocString)
+        SysFreeString(bstrHelpFile)
+      }
+      return (name: String(from: bstrName),
+              docstring: String(from: bstrDocString),
+              help: (context: dwHelpContext, file: String(from: bstrHelpFile)))
     }
-    return (name: String(from: bstrName), docstring: String(from: bstrDocString),
-            help: (context: dwHelpContext, file: String(from: bstrHelpFile)))
   }
 
   /// Indicates whether a passed-in string contains the name of a type or member
   /// described in the library.
   public func IsName(_ name: String, _ hash: ULONG) throws -> Bool {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ITypeLib.self) { pThis in
+      var szNameBuf: [OLECHAR] = Array<OLECHAR>(from: name)
+      var fName: WindowsBool = false
+      let hr: HRESULT =
+          pThis.pointee.lpVtbl.pointee.IsName(pThis, &szNameBuf, hash, &fName)
+      guard hr == S_OK else { throw COMError(hr: hr) }
+      return fName == true
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ITypeLib.self, capacity: 1)
-
-    var szNameBuf: [OLECHAR] = Array<OLECHAR>(from: name)
-    var fName: WindowsBool = false
-    let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.IsName(pThis, &szNameBuf, hash, &fName)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-    return fName == true
   }
 
   /// Finds occurrences of a type description in a type library.  This may be
   /// used to quickly verify that a name exists in a type library.
   public func FindName(_ name: String, _ lHashVal: ULONG = 0)
       throws -> [(ITypeInfo, MEMBERID)] {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
-    }
-    let pThis = pUnk.bindMemory(to: WinSDK.ITypeLib.self, capacity: 1)
+    return try perform(as: WinSDK.ITypeLib.self) { pThis in
+      var szNameBuf: [OLECHAR] = Array<OLECHAR>(from: name)
+      var pTInfo: [UnsafeMutablePointer<WinSDK.ITypeInfo>?] = []
+      var rgMemId: [MEMBERID] = []
+      var cFound: USHORT = 0
+      var hr: HRESULT = S_OK
 
-    var szNameBuf: [OLECHAR] = Array<OLECHAR>(from: name)
-    var pTInfo: [UnsafeMutablePointer<WinSDK.ITypeInfo>?] = []
-    var rgMemId: [MEMBERID] = []
-    var cFound: USHORT = 0
-    var hr: HRESULT = S_OK
+      hr = pThis.pointee.lpVtbl.pointee.FindName(pThis, &szNameBuf, lHashVal,
+                                                &pTInfo, &rgMemId, &cFound)
+      guard hr == S_OK else { throw COMError(hr: hr) }
 
-    hr = pThis.pointee.lpVtbl.pointee.FindName(pThis, &szNameBuf, lHashVal,
-                                               &pTInfo, &rgMemId, &cFound)
-    guard hr == S_OK else { throw COMError(hr: hr) }
+      pTInfo = Array<UnsafeMutablePointer<WinSDK.ITypeInfo>?>(repeating: nil,
+                                                              count: Int(cFound))
+      rgMemId = Array<MEMBERID>(repeating: MEMBERID_NIL, count: Int(cFound))
 
-    pTInfo = Array<UnsafeMutablePointer<WinSDK.ITypeInfo>?>(repeating: nil,
-                                                            count: Int(cFound))
-    rgMemId = Array<MEMBERID>(repeating: MEMBERID_NIL, count: Int(cFound))
+      hr = pThis.pointee.lpVtbl.pointee.FindName(pThis, &szNameBuf, lHashVal,
+                                                &pTInfo, &rgMemId, &cFound)
+      guard hr == S_OK else { throw COMError(hr: hr) }
 
-    hr = pThis.pointee.lpVtbl.pointee.FindName(pThis, &szNameBuf, lHashVal,
-                                               &pTInfo, &rgMemId, &cFound)
-    guard hr == S_OK else { throw COMError(hr: hr) }
-
-    return (0 ..< cFound).map {
-      (ITypeInfo(pUnk: pTInfo[Int($0)]), rgMemId[Int($0)])
+      return (0 ..< cFound).map {
+        (ITypeInfo(pUnk: pTInfo[Int($0)]), rgMemId[Int($0)])
+      }
     }
   }
 
   /// Releases the TLIBATTR originally obtained from `GetLibAttr`.
   public func ReleaseTLibAttr(_ pTLibAttr: UnsafeMutablePointer<TLIBATTR>)
       throws {
-    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
-      throw COMError(hr: E_INVALIDARG)
+    return try perform(as: WinSDK.ITypeLib.self) { pThis in
+      pThis.pointee.lpVtbl.pointee.ReleaseTLibAttr(pThis, pTLibAttr)
     }
-    let pThis = pUnk.bindMemory(to: WinSDK.ITypeLib.self, capacity: 1)
-
-    pThis.pointee.lpVtbl.pointee.ReleaseTLibAttr(pThis, pTLibAttr)
   }
 }

--- a/Sources/SwiftCOM/Interfaces/IUnknown.swift
+++ b/Sources/SwiftCOM/Interfaces/IUnknown.swift
@@ -69,3 +69,16 @@ extension IUnknown {
     return T(pUnk: pointer)
   }
 }
+
+extension IUnknown {
+  func perform<Type, ResultType>(as type: Type.Type,
+                                 _ body: (UnsafeMutablePointer<Type>) throws -> ResultType)
+      throws -> ResultType {
+    guard let pUnk = UnsafeMutableRawPointer(self.pUnk) else {
+      throw COMError(hr: E_INVALIDARG)
+    }
+    let pThis = pUnk.bindMemory(to: Type.self, capacity: 1)
+
+    return try body(pThis)
+  }
+}


### PR DESCRIPTION
Add a new helper to execute a closure as a specific type.  The idea
to use the type as an argument is originally from STREGA's Gate which
made this abstraction possible.