### PR TITLE
Interfaces: convert to use `CHECKED`

### DIFF
--- a/Sources/SwiftCOM/COMBase.swift
+++ b/Sources/SwiftCOM/COMBase.swift
@@ -24,7 +24,6 @@ public func CoInitializeEx(_ dwCoInit: COINIT = COINIT_MULTITHREADED) throws {
 public func CoGetMalloc() throws -> IMalloc {
   var pMalloc: LPMALLOC?
   // MSDN: dwMemContext: This parameter must be 1.
-  let hr: HRESULT = CoGetMalloc(1, &pMalloc)
-  guard hr == S_OK else { throw COMError(hr: hr) }
+  try CHECKED(CoGetMalloc(1, &pMalloc))
   return IMalloc(pUnk: pMalloc)
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IBindCtx.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IBindCtx.swift
@@ -13,9 +13,7 @@ public class IBindCtx: IUnknown {
   public func EnumObjectParam() throws -> IEnumString {
     return try perform(as: WinSDK.IBindCtx.self) { pThis in
       var penum: UnsafeMutablePointer<WinSDK.IEnumString>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.EnumObjectParam(pThis, &penum)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.EnumObjectParam(pThis, &penum))
       return IEnumString(pUnk: penum)
     }
   }
@@ -23,9 +21,7 @@ public class IBindCtx: IUnknown {
   public func GetBindOptions() throws -> BIND_OPTS {
     return try perform(as: WinSDK.IBindCtx.self) { pThis in
       var bindopts: BIND_OPTS = BIND_OPTS()
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetBindOptions(pThis, &bindopts)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetBindOptions(pThis, &bindopts))
       return bindopts
     }
   }
@@ -34,9 +30,7 @@ public class IBindCtx: IUnknown {
     return try perform(as: WinSDK.IBindCtx.self) { pThis in
       var pUnk: UnsafeMutablePointer<WinSDK.IUnknown>?
       var key: [OLECHAR] = pszKey.wide
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetObjectParam(pThis, &key, &pUnk)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetObjectParam(pThis, &key, &pUnk))
       return IUnknown(pUnk: pUnk)
     }
   }
@@ -44,18 +38,14 @@ public class IBindCtx: IUnknown {
   public func GetRunningObjectTable() throws -> IRunningObjectTable {
     return try perform(as: WinSDK.IBindCtx.self) { pThis in
       var prot: UnsafeMutablePointer<WinSDK.IRunningObjectTable>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetRunningObjectTable(pThis, &prot)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetRunningObjectTable(pThis, &prot))
       return IRunningObjectTable(pUnk: prot)
     }
   }
 
   public func RegisterObjectBound(_ pUnk: IUnknown) throws {
     return try perform(as: WinSDK.IBindCtx.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.RegisterObjectBound(pThis, pUnk.pUnk)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.RegisterObjectBound(pThis, RawPointer(pUnk)))
     }
   }
 
@@ -63,42 +53,32 @@ public class IBindCtx: IUnknown {
       throws {
     return try perform(as: WinSDK.IBindCtx.self) { pThis in
       var key: [OLECHAR] = pszKey.wide
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.RegisterObjectParam(pThis, &key,
-                                                           pUnk.pUnk)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.RegisterObjectParam(pThis, &key, RawPointer(pUnk)))
     }
   }
 
   public func ReleaseBoundObjects() throws {
     return try perform(as: WinSDK.IBindCtx.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.ReleaseBoundObjects(pThis)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.ReleaseBoundObjects(pThis))
     }
   }
 
-  public func RevokeObjectBound(_ punk: IUnknown) throws {
+  public func RevokeObjectBound(_ pUnk: IUnknown) throws {
     return try perform(as: WinSDK.IBindCtx.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.RevokeObjectBound(pThis, punk.pUnk)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.RevokeObjectBound(pThis, RawPointer(pUnk)))
     }
   }
 
   public func RevokeObjectParam(_ pszKey: String) throws {
     return try perform(as: WinSDK.IBindCtx.self) { pThis in
       var key: [OLECHAR] = pszKey.wide
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.RevokeObjectParam(pThis, &key)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.RevokeObjectParam(pThis, &key))
     }
   }
 
   public func SetBindOptions(_ pbindopts: inout BIND_OPTS) throws {
     return try perform(as: WinSDK.IBindCtx.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.SetBindOptions(pThis, &pbindopts)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetBindOptions(pThis, &pbindopts))
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IEnumMoniker.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IEnumMoniker.swift
@@ -13,8 +13,7 @@ public class IEnumMoniker: IUnknown {
   public func Clone() throws -> IEnumMoniker {
     return try perform(as: WinSDK.IEnumMoniker.self) { pThis in
       var penum: UnsafeMutablePointer<WinSDK.IEnumMoniker>?
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Clone(pThis, &penum)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Clone(pThis, &penum))
       return IEnumMoniker(pUnk: penum)
     }
   }
@@ -23,10 +22,7 @@ public class IEnumMoniker: IUnknown {
     return try perform(as: WinSDK.IEnumMoniker.self) { pThis in
       var rgelt: UnsafeMutablePointer<WinSDK.IMoniker>?
       var celtFetched: ULONG = 0
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.Next(pThis, celt, &rgelt, &celtFetched)
-      guard hr == S_OK else { throw COMError(hr: hr) }
-
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Next(pThis, celt, &rgelt, &celtFetched))
       defer { CoTaskMemFree(rgelt) }
 
       var monikers: [IMoniker] = []
@@ -43,15 +39,13 @@ public class IEnumMoniker: IUnknown {
 
   public func Reset() throws {
     return try perform(as: WinSDK.IEnumMoniker.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Reset(pThis)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Reset(pThis))
     }
   }
 
   public func Skip(_ celt: ULONG) throws {
     return try perform(as: WinSDK.IEnumMoniker.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Skip(pThis, celt)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Skip(pThis, celt))
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IEnumString.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IEnumString.swift
@@ -13,8 +13,7 @@ public class IEnumString: IUnknown {
   public func Clone() throws -> IEnumString {
     return try perform(as: WinSDK.IEnumString.self) { pThis in
       var penum: UnsafeMutablePointer<WinSDK.IEnumString>?
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Clone(pThis, &penum)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Clone(pThis, &penum))
       return IEnumString(pUnk: penum)
     }
   }
@@ -23,10 +22,7 @@ public class IEnumString: IUnknown {
     return try perform(as: WinSDK.IEnumString.self) { pThis in
       var rgelt: LPOLESTR?
       var celtFetched: ULONG = 0
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.Next(pThis, celt, &rgelt, &celtFetched)
-      guard hr == S_OK else { throw COMError(hr: hr) }
-
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Next(pThis, celt, &rgelt, &celtFetched))
       defer { CoTaskMemFree(rgelt) }
 
       var result: [String] = []
@@ -43,15 +39,13 @@ public class IEnumString: IUnknown {
 
   public func Reset() throws {
     return try perform(as: WinSDK.IEnumString.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Reset(pThis)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Reset(pThis))
     }
   }
 
   public func Skip(_ celt: ULONG) throws {
     return try perform(as: WinSDK.IEnumString.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Skip(pThis, celt)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Skip(pThis, celt))
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IEnumUnknown.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IEnumUnknown.swift
@@ -13,8 +13,7 @@ public class IEnumUnknown: IUnknown {
   public func Clone() throws -> IEnumUnknown {
     return try perform(as: WinSDK.IEnumUnknown.self) { pThis in
       var penum: UnsafeMutablePointer<WinSDK.IEnumUnknown>?
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Clone(pThis, &penum)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Clone(pThis, &penum))
       return IEnumUnknown(pUnk: penum)
     }
   }
@@ -23,9 +22,7 @@ public class IEnumUnknown: IUnknown {
     return try perform(as: WinSDK.IEnumUnknown.self) { pThis in
       var rgelt: UnsafeMutablePointer<WinSDK.IUnknown>?
       var celtFetched: ULONG = 0
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.Next(pThis, celt, &rgelt, &celtFetched)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Next(pThis, celt, &rgelt, &celtFetched))
 
       var result: [IUnknown] = []
       result.reserveCapacity(Int(celtFetched))
@@ -41,15 +38,13 @@ public class IEnumUnknown: IUnknown {
 
   public func Reset() throws {
     return try perform(as: WinSDK.IEnumUnknown.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Reset(pThis)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Reset(pThis))
     }
   }
 
   public func Skip(_ celt: ULONG) throws {
     return try perform(as: WinSDK.IEnumUnknown.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Skip(pThis, celt)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Skip(pThis, celt))
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IErrorLog.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IErrorLog.swift
@@ -13,12 +13,13 @@ public class IErrorLog: IUnknown {
   public func AddError(_ szPropName: String, _ pExcepInfo: [EXCEPINFO]) throws {
     return try perform(as: WinSDK.IErrorLog.self) { pThis in
       var pExcepInfo = pExcepInfo
-      let hr: HRESULT = szPropName.withCString(encodedAs: UTF16.self) { pwszPropName in
-        pExcepInfo.withUnsafeMutableBufferPointer {
-          pThis.pointee.lpVtbl.pointee.AddError(pThis, pwszPropName, $0.baseAddress)
+      try CHECKED {
+        szPropName.withCString(encodedAs: UTF16.self) { pwszPropName in
+          pExcepInfo.withUnsafeMutableBufferPointer {
+            pThis.pointee.lpVtbl.pointee.AddError(pThis, pwszPropName, $0.baseAddress)
+          }
         }
       }
-      guard hr == S_OK else { throw COMError(hr: hr) }
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IFileOperation.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IFileOperation.swift
@@ -13,29 +13,20 @@ public class IFileOperation: IUnknown {
   public func Advise(_ pfops: IFileOperationProgressSink) throws -> DWORD {
     return try perform(as: WinSDK.IFileOperation.self) { pThis in
       var dwCookie: DWORD = 0
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.Advise(pThis, RawPointer(pfops),
-                                              &dwCookie)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Advise(pThis, RawPointer(pfops), &dwCookie))
       return dwCookie
     }
   }
 
   public func ApplyPropertiesToItem(_ psiItem: IShellItem) throws {
     return try perform(as: WinSDK.IFileOperation.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.ApplyPropertiesToItem(pThis,
-                                                            RawPointer(psiItem))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.ApplyPropertiesToItem(pThis, RawPointer(psiItem)))
     }
   }
 
   public func ApplyPropertiesToItems(_ punkItems: IUnknown) throws {
     return try perform(as: WinSDK.IFileOperation.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.ApplyPropertiesToItems(pThis,
-                                                              punkItems.pUnk)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.ApplyPropertiesToItems(pThis, RawPointer(punkItems)))
     }
   }
 
@@ -44,50 +35,34 @@ public class IFileOperation: IUnknown {
                        _ pszCopyName: String?,
                        _ pfopsItem: IFileOperationProgressSink?) throws {
     return try perform(as: WinSDK.IFileOperation.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.CopyItem(pThis, RawPointer(psiItem),
-                                                RawPointer(psiDestinationFolder),
-                                                pszCopyName?.wide,
-                                                RawPointer(pfopsItem))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.CopyItem(pThis, RawPointer(psiItem), RawPointer(psiDestinationFolder), pszCopyName?.wide, RawPointer(pfopsItem)))
     }
   }
 
   public func CopyItems(_ punkItems: IUnknown,
                         _ psiDestinationFolder: IShellItem) throws {
     return try perform(as: WinSDK.IFileOperation.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.CopyItems(pThis, punkItems.pUnk,
-                                                RawPointer(psiDestinationFolder))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.CopyItems(pThis, RawPointer(punkItems), RawPointer(psiDestinationFolder)))
     }
   }
 
   public func DeleteItem(_ psiItem: IShellItem,
                          _ pfopsItem: IFileOperationProgressSink?) throws {
     return try perform(as: WinSDK.IFileOperation.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.DeleteItem(pThis, RawPointer(psiItem),
-                                                  RawPointer(pfopsItem))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.DeleteItem(pThis, RawPointer(psiItem), RawPointer(pfopsItem)))
     }
   }
 
   public func DeleteItems(_ punkItems: IUnknown) throws {
     return try perform(as: WinSDK.IFileOperation.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.DeleteItems(pThis, punkItems.pUnk)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.DeleteItems(pThis, punkItems.pUnk))
     }
   }
 
   public func GetAnyOperationsAborted() throws -> Bool {
     return try perform(as: WinSDK.IFileOperation.self) { pThis in
       var fAnyOperationsAborted: WindowsBool = false
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetAnyOperationsAborted(pThis,
-                                                               &fAnyOperationsAborted)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetAnyOperationsAborted(pThis, &fAnyOperationsAborted))
       return fAnyOperationsAborted == true
     }
   }
@@ -97,22 +72,14 @@ public class IFileOperation: IUnknown {
                        _ pszNewName: String?,
                        _ pfopsItem: IFileOperationProgressSink?) throws {
     return try perform(as: WinSDK.IFileOperation.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.MoveItem(pThis, RawPointer(psiItem),
-                                                RawPointer(psiDestinationFolder),
-                                                pszNewName?.wide,
-                                                RawPointer(pfopsItem))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.MoveItem(pThis, RawPointer(psiItem), RawPointer(psiDestinationFolder), pszNewName?.wide, RawPointer(pfopsItem)))
     }
   }
 
   public func MoveItems(_ punkItems: IUnknown,
                         _ psiDestinationFolder: IShellItem) throws {
     return try perform(as: WinSDK.IFileOperation.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.MoveItems(pThis, punkItems.pUnk,
-                                                RawPointer(psiDestinationFolder))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.MoveItems(pThis, RawPointer(punkItems), RawPointer(psiDestinationFolder)))
     }
   }
 
@@ -121,92 +88,63 @@ public class IFileOperation: IUnknown {
                       _ pszTemplateName: String?,
                       _ pfopsItem: IFileOperationProgressSink?) throws {
     return try perform(as: WinSDK.IFileOperation.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.NewItem(pThis,
-                                              RawPointer(psiDestinationFolder),
-                                              dwFileAttributes, pszName.wide,
-                                              pszTemplateName?.wide,
-                                              RawPointer(pfopsItem))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.NewItem(pThis, RawPointer(psiDestinationFolder), dwFileAttributes, pszName.wide, pszTemplateName?.wide, RawPointer(pfopsItem)))
     }
   }
 
   public func PerformOperations() throws {
     return try perform(as: WinSDK.IFileOperation.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.PerformOperations(pThis)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.PerformOperations(pThis))
     }
   }
 
   public func RenameItem(_ psiItem: IShellItem, _ pszNewName: String,
                          _ pfopsItem: IFileOperationProgressSink?) throws {
     return try perform(as: WinSDK.IFileOperation.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.RenameItem(pThis, RawPointer(psiItem),
-                                                  pszNewName.wide,
-                                                  RawPointer(pfopsItem))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.RenameItem(pThis, RawPointer(psiItem), pszNewName.wide, RawPointer(pfopsItem)))
     }
   }
 
   public func RenameItems(_ pUnkItems: IUnknown,
                           _ pszNewName: String) throws {
     return try perform(as: WinSDK.IFileOperation.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.RenameItems(pThis, pUnkItems.pUnk,
-                                                  pszNewName.wide)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.RenameItems(pThis, RawPointer(pUnkItems), pszNewName.wide))
     }
   }
 
   public func SetOperationFlags(_ dwOperationFlags: DWORD) throws {
     return try perform(as: WinSDK.IFileOperation.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.SetOperationFlags(pThis,
-                                                         dwOperationFlags)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetOperationFlags(pThis, dwOperationFlags))
     }
   }
 
   public func SetOwnerWindow(_ hwndOwner: HWND) throws {
     return try perform(as: WinSDK.IFileOperation.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.SetOwnerWindow(pThis, hwndOwner)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetOwnerWindow(pThis, hwndOwner))
     }
   }
 
   public func SetProgressDialog(_ popd: IOperationsProgressDialog) throws {
     return try perform(as: WinSDK.IFileOperation.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.SetProgressDialog(pThis,
-                                                         RawPointer(popd))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetProgressDialog(pThis, RawPointer(popd)))
     }
   }
 
   public func SetProgressMessage(_ pszMessage: String) throws {
     return try perform(as: WinSDK.IFileOperation.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.SetProgressMessage(pThis,
-                                                          pszMessage.wide)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetProgressMessage(pThis, pszMessage.wide))
     }
   }
 
   public func SetProperties(_ ppropArray: IPropertyChangeArray) throws {
     return try perform(as: WinSDK.IFileOperation.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.SetProperties(pThis,
-                                                     RawPointer(ppropArray))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetProperties(pThis, RawPointer(ppropArray)))
     }
   }
 
   public func Unadvise(_ dwCookie: DWORD) throws {
     return try perform(as: WinSDK.IFileOperation.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Unadvise(pThis, dwCookie)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Unadvise(pThis, dwCookie))
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IMoniker.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IMoniker.swift
@@ -15,11 +15,7 @@ public class IMoniker: IPersistStream {
     return try perform(as: WinSDK.IMoniker.self) { pThis in
       var iid: IID = riidResult
       var pvResult: UnsafeMutableRawPointer?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.BindToObject(pThis, RawPointer(pbc),
-                                                    RawPointer(pmkToLeft),
-                                                    &iid, &pvResult)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.BindToObject(pThis, RawPointer(pbc), RawPointer(pmkToLeft), &iid, &pvResult))
       return IUnknown(pUnk: pvResult)
     }
   }
@@ -28,11 +24,7 @@ public class IMoniker: IPersistStream {
                             _ riid: inout IID) throws -> IUnknown {
     return try perform(as: WinSDK.IMoniker.self) { pThis in
       var pvObj: UnsafeMutableRawPointer?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.BindToObject(pThis, RawPointer(pbc),
-                                                    RawPointer(pmkToLeft),
-                                                    &riid, &pvObj)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.BindToObject(pThis, RawPointer(pbc), RawPointer(pmkToLeft), &riid, &pvObj))
       return IUnknown(pUnk: pvObj)
     }
   }
@@ -40,11 +32,7 @@ public class IMoniker: IPersistStream {
   public func CommonPrefixWith(_ pmkOther: IMoniker) throws -> IMoniker {
     return try perform(as: WinSDK.IMoniker.self) { pThis in
       var pmkPrefix: UnsafeMutablePointer<WinSDK.IMoniker>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.CommonPrefixWith(pThis,
-                                                        RawPointer(pmkOther),
-                                                        &pmkPrefix)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.CommonPrefixWith(pThis, RawPointer(pmkOther), &pmkPrefix))
       return IMoniker(pUnk: pmkPrefix)
     }
   }
@@ -53,11 +41,7 @@ public class IMoniker: IPersistStream {
       throws -> IMoniker {
     return try perform(as: WinSDK.IMoniker.self) { pThis in
       var pmkComposite: UnsafeMutablePointer<WinSDK.IMoniker>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.ComposeWith(pThis, RawPointer(pmkRight),
-                                                  WindowsBool(fOnlyIfNotGeneric == true),
-                                                  &pmkComposite)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.ComposeWith(pThis, RawPointer(pmkRight), WindowsBool(fOnlyIfNotGeneric == true), &pmkComposite))
       return IMoniker(pUnk: pmkComposite)
     }
   }
@@ -65,10 +49,7 @@ public class IMoniker: IPersistStream {
   public func Enum(_ fForward: Bool) throws -> IEnumMoniker {
     return try perform(as: WinSDK.IMoniker.self) { pThis in
       var penumMoniker: UnsafeMutablePointer<WinSDK.IEnumMoniker>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.Enum(pThis, WindowsBool(fForward == true),
-                                            &penumMoniker)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Enum(pThis, WindowsBool(fForward == true), &penumMoniker))
       return IEnumMoniker(pUnk: penumMoniker)
     }
   }
@@ -80,11 +61,7 @@ public class IMoniker: IPersistStream {
       defer { _ = try? malloc.Release() }
 
       var pszDisplayName: LPOLESTR?
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee
-                            .GetDisplayName(pThis, RawPointer(pbc),
-                                            RawPointer(pmkToLeft), &pszDisplayName)
-      guard hr == S_OK else { throw COMError(hr: hr) }
-
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetDisplayName(pThis, RawPointer(pbc), RawPointer(pmkToLeft), &pszDisplayName))
       defer { try? malloc.Free(pszDisplayName) }
       return String(decodingCString: pszDisplayName!, as: UTF16.self)
     }
@@ -94,10 +71,7 @@ public class IMoniker: IPersistStream {
       throws -> FILETIME {
     return try perform(as: WinSDK.IMoniker.self) { pThis in
       var FileTime: FILETIME = FILETIME()
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee
-                            .GetTimeOfLastChange(pThis, RawPointer(pbc),
-                                                RawPointer(pmkToLeft), &FileTime)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetTimeOfLastChange(pThis, RawPointer(pbc), RawPointer(pmkToLeft), &FileTime))
       return FileTime
     }
   }
@@ -105,8 +79,7 @@ public class IMoniker: IPersistStream {
   public func Hash() throws -> DWORD {
     return try perform(as: WinSDK.IMoniker.self) { pThis in
       var dwHash: DWORD = 0
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Hash(pThis, &dwHash)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Hash(pThis, &dwHash))
       return dwHash
     }
   }
@@ -114,16 +87,14 @@ public class IMoniker: IPersistStream {
   public func Inverse() throws -> IMoniker {
     return try perform(as: WinSDK.IMoniker.self) { pThis in
       var pmk: UnsafeMutablePointer<WinSDK.IMoniker>?
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Inverse(pThis, &pmk)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Inverse(pThis, &pmk))
       return IMoniker(pUnk: pmk)
     }
   }
 
   public func IsEqual(_ pmkOtherMoniker: IMoniker) throws -> Bool {
     return try perform(as: WinSDK.IMoniker.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.IsEqual(pThis, RawPointer(pmkOtherMoniker))
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.IsEqual(pThis, RawPointer(pmkOtherMoniker))
       switch hr {
       case S_OK: return true
       case S_FALSE: return false
@@ -135,10 +106,7 @@ public class IMoniker: IPersistStream {
   public func IsRunning(_ pbc: IBindCtx, _ pmkToLeft: IMoniker?,
                         _ pmkNewlyRunning: IMoniker?) throws -> Bool {
     return try perform(as: WinSDK.IMoniker.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.IsRunning(pThis, RawPointer(pbc),
-                                                RawPointer(pmkToLeft),
-                                                RawPointer(pmkNewlyRunning))
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.IsRunning(pThis, RawPointer(pbc), RawPointer(pmkToLeft), RawPointer(pmkNewlyRunning))
       switch hr {
       case S_OK: return true
       case S_FALSE: return false
@@ -150,8 +118,7 @@ public class IMoniker: IPersistStream {
   public func IsSystemMoniker() throws -> DWORD {
     return try perform(as: WinSDK.IMoniker.self) { pThis in
       var dwMksys: DWORD = 0
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.IsSystemMoniker(pThis, &dwMksys)
+      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.IsSystemMoniker(pThis, &dwMksys)
       switch hr {
       case S_OK: return dwMksys
       case S_FALSE: return DWORD(MKSYS_NONE.rawValue)
@@ -167,12 +134,11 @@ public class IMoniker: IPersistStream {
       var chEaten: ULONG = 0
       var pmkOut: UnsafeMutablePointer<WinSDK.IMoniker>?
       var olestr: [OLECHAR] = pszDisplayName.wide
-      let hr: HRESULT = olestr.withUnsafeMutableBufferPointer {
-        pThis.pointee.lpVtbl.pointee
-            .ParseDisplayName(pThis, RawPointer(pbc), RawPointer(pmkToLeft),
-                              $0.baseAddress, &chEaten, &pmkOut)
+      try CHECKED {
+        olestr.withUnsafeMutableBufferPointer {
+          pThis.pointee.lpVtbl.pointee.ParseDisplayName(pThis, RawPointer(pbc), RawPointer(pmkToLeft), $0.baseAddress, &chEaten, &pmkOut)
+        }
       }
-      guard hr == S_OK else { throw COMError(hr: hr) }
       return (Int(chEaten), IMoniker(pUnk: pmkOut))
     }
   }
@@ -183,11 +149,7 @@ public class IMoniker: IPersistStream {
       var ppmkToLeft: UnsafeMutablePointer<WinSDK.IMoniker>? =
           RawPointer(pmkToLeft)
       var pmkReduced: UnsafeMutablePointer<WinSDK.IMoniker>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.Reduce(pThis, RawPointer(pbc),
-                                              dwReduceHowFar, &ppmkToLeft,
-                                              &pmkReduced)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Reduce(pThis, RawPointer(pbc), dwReduceHowFar, &ppmkToLeft, &pmkReduced))
       pmkToLeft = IMoniker(pUnk: ppmkToLeft)
       return IMoniker(pUnk: pmkReduced)
     }
@@ -196,10 +158,7 @@ public class IMoniker: IPersistStream {
   public func RelativePathTo(_ pmkOther: IMoniker) throws -> IMoniker {
     return try perform(as: WinSDK.IMoniker.self) { pThis in
       var pmkRelPath: UnsafeMutablePointer<WinSDK.IMoniker>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.RelativePathTo(pThis, RawPointer(pmkOther),
-                                                      &pmkRelPath)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.RelativePathTo(pThis, RawPointer(pmkOther), &pmkRelPath))
       return IMoniker(pUnk: pmkRelPath)
     }
   }

--- a/Sources/SwiftCOM/Interfaces/Human/IObjectWithPropertyKey.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IObjectWithPropertyKey.swift
@@ -13,16 +13,14 @@ public class IObjectWithPropertyKey: IUnknown {
   public func GetPropertyKey() throws -> PROPERTYKEY {
     return try perform(as: WinSDK.IObjectWithPropertyKey.self) { pThis in
       var key: PROPERTYKEY = PROPERTYKEY()
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetPropertyKey(pThis, &key)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetPropertyKey(pThis, &key))
       return key
     }
   }
 
   public func SetPropertyKey(_ key: REFPROPERTYKEY) throws {
     return try perform(as: WinSDK.IObjectWithPropertyKey.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.SetPropertyKey(pThis, key)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetPropertyKey(pThis, key))
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IOperationsProgressDialog.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IOperationsProgressDialog.swift
@@ -14,10 +14,7 @@ public class IOperationsProgressDialog: IUnknown {
     return try perform(as: WinSDK.IOperationsProgressDialog.self) { pThis in
       var ullElapsed: ULONGLONG = 0
       var ullRemaining: ULONGLONG = 0
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetMilliseconds(pThis, &ullElapsed,
-                                                      &ullRemaining)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetMilliseconds(pThis, &ullElapsed, &ullRemaining))
       return (ullElapsed, ullRemaining)
     }
   }
@@ -25,72 +22,57 @@ public class IOperationsProgressDialog: IUnknown {
   public func GetOperationStatus() throws -> PDOPSTATUS {
     return try perform(as: WinSDK.IOperationsProgressDialog.self) { pThis in
       var opstatus: PDOPSTATUS = PDOPSTATUS(0)
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetOperationStatus(pThis, &opstatus)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetOperationStatus(pThis, &opstatus))
       return opstatus
     }
   }
 
   public func PauseTimer() throws {
     return try perform(as: WinSDK.IOperationsProgressDialog.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.PauseTimer(pThis)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.PauseTimer(pThis))
     }
   }
 
   public func ResetTimer() throws {
     return try perform(as: WinSDK.IOperationsProgressDialog.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.ResetTimer(pThis)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.ResetTimer(pThis))
     }
   }
 
   public func ResumeTimer() throws {
     return try perform(as: WinSDK.IOperationsProgressDialog.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.ResumeTimer(pThis)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.ResumeTimer(pThis))
     }
   }
 
   public func SetMode(_ mode: PDMODE) throws {
     return try perform(as: WinSDK.IOperationsProgressDialog.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.SetMode(pThis, mode)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetMode(pThis, mode))
     }
   }
 
   public func SetOperation(_ action: SPACTION) throws {
     return try perform(as: WinSDK.IOperationsProgressDialog.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.SetOperation(pThis, action)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetOperation(pThis, action))
     }
   }
 
   public func StartProgressDialog(_ hwnd: HWND, _ flags: OPPROGDLGF) throws {
     return try perform(as: WinSDK.IOperationsProgressDialog.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.StartProgressDialog(pThis, hwnd, flags)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.StartProgressDialog(pThis, hwnd, flags))
     }
   }
 
   public func StopProgressDialog() throws {
     return try perform(as: WinSDK.IOperationsProgressDialog.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.StopProgressDialog(pThis)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.StopProgressDialog(pThis))
     }
   }
 
   public func UpdateLocations(_ psiSource: IShellItem, _ psiTarget: IShellItem,
                               _ psiItem: IShellItem) throws {
     return try perform(as: WinSDK.IOperationsProgressDialog.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.UpdateLocations(pThis,
-                                                      RawPointer(psiSource),
-                                                      RawPointer(psiTarget),
-                                                      RawPointer(psiItem))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.UpdateLocations(pThis, RawPointer(psiSource), RawPointer(psiTarget), RawPointer(psiItem)))
     }
   }
 
@@ -101,14 +83,7 @@ public class IOperationsProgressDialog: IUnknown {
                              _ ullItemsCurrent: ULONGLONG,
                              _ ullItemsTotal: ULONGLONG) throws {
     return try perform(as: WinSDK.IOperationsProgressDialog.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.UpdateProgress(pThis, ullPointsCurrent,
-                                                      ullPointsTotal,
-                                                      ullSizeCurrent,
-                                                      ullSizeTotal,
-                                                      ullItemsCurrent,
-                                                      ullItemsTotal)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.UpdateProgress(pThis, ullPointsCurrent, ullPointsTotal, ullSizeCurrent, ullSizeTotal, ullItemsCurrent, ullItemsTotal))
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IPersist.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IPersist.swift
@@ -13,8 +13,7 @@ public class IPersist: IPersistStream {
   public func GetClassID() throws -> CLSID {
     return try perform(as: WinSDK.IPersist.self) { pThis in
       var ClassID: CLSID = CLSID()
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetClassID(pThis, &ClassID)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetClassID(pThis, &ClassID))
       return ClassID
     }
   }

--- a/Sources/SwiftCOM/Interfaces/Human/IPersistStream.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IPersistStream.swift
@@ -13,8 +13,7 @@ public class IPersistStream: IUnknown {
   public func GetSizeMax() throws -> ULARGE_INTEGER {
     return try perform(as: WinSDK.IPersistStream.self) { pThis in
       var cbSize: ULARGE_INTEGER = ULARGE_INTEGER()
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetSizeMax(pThis, &cbSize)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetSizeMax(pThis, &cbSize))
       return cbSize
     }
   }
@@ -32,17 +31,13 @@ public class IPersistStream: IUnknown {
 
   public func Load(_ pStm: IStream) throws {
     return try perform(as: WinSDK.IPersistStream.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Load(pThis, RawPointer(pStm))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Load(pThis, RawPointer(pStm)))
     }
   }
 
   public func Save(_ pStm: IStream, _ fClearDirty: Bool) throws {
     return try perform(as: WinSDK.IPersistStream.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.Save(pThis, RawPointer(pStm),
-                                            WindowsBool(fClearDirty == true))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Save(pThis, RawPointer(pStm), WindowsBool(fClearDirty == true)))
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IPortableDeviceKeyCollection.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IPortableDeviceKeyCollection.swift
@@ -12,23 +12,20 @@ public class IPortableDeviceKeyCollection: IUnknown {
 
   public func Add(_ Key: REFPROPERTYKEY) throws {
     return try perform(as: WinSDK.IPortableDeviceKeyCollection.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Add(pThis, Key)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Add(pThis, Key))
     }
   }
 
   public func Clear() throws {
     return try perform(as: WinSDK.IPortableDeviceKeyCollection.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Clear(pThis)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Clear(pThis))
     }
   }
 
   public func GetAt(_ dwIndex: DWORD) throws -> PROPERTYKEY {
     return try perform(as: WinSDK.IPortableDeviceKeyCollection.self) { pThis in
       var Key: PROPERTYKEY = PROPERTYKEY()
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetAt(pThis, dwIndex, &Key)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, dwIndex, &Key))
       return Key
     }
   }
@@ -36,16 +33,14 @@ public class IPortableDeviceKeyCollection: IUnknown {
   public func GetCount() throws -> DWORD {
     return try perform(as: WinSDK.IPortableDeviceKeyCollection.self) { pThis in
       var cElems: DWORD = DWORD(0)
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetCount(pThis, &cElems)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetCount(pThis, &cElems))
       return cElems
     }
   }
 
   public func RemoveAt(_ dwIndex: DWORD) throws {
     return try perform(as: WinSDK.IPortableDeviceKeyCollection.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.RemoveAt(pThis, dwIndex)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveAt(pThis, dwIndex))
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IPortableDevicePropVariantCollection.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IPortableDevicePropVariantCollection.swift
@@ -13,32 +13,30 @@ public class IPortableDevicePropVariantCollection: IUnknown {
   public func Add(_ value: PROPVARIANT) throws {
     return try perform(as: WinSDK.IPortableDevicePropVariantCollection.self) { pThis in
       var value = value
-      let hr: HRESULT = withUnsafePointer(to: &value) {
-        pThis.pointee.lpVtbl.pointee.Add(pThis, $0)
+      try CHECKED {
+        withUnsafePointer(to: &value) {
+          pThis.pointee.lpVtbl.pointee.Add(pThis, $0)
+        }
       }
-      guard hr == S_OK else { throw COMError(hr: hr) }
     }
   }
 
   public func ChangeType(_ vt: VARTYPE) throws {
     return try perform(as: WinSDK.IPortableDevicePropVariantCollection.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.ChangeType(pThis, vt)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.ChangeType(pThis, vt))
     }
   }
 
   public func Clear() throws {
     return try perform(as: WinSDK.IPortableDevicePropVariantCollection.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Clear(pThis)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Clear(pThis))
     }
   }
 
   public func GetAt(_ dwIndex: DWORD) throws -> PROPVARIANT {
     return try perform(as: WinSDK.IPortableDevicePropVariantCollection.self) { pThis in
       var Value: PROPVARIANT = PROPVARIANT()
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetAt(pThis, dwIndex, &Value)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, dwIndex, &Value))
       return Value
     }
   }
@@ -46,8 +44,7 @@ public class IPortableDevicePropVariantCollection: IUnknown {
   public func GetCount() throws -> DWORD {
     return try perform(as: WinSDK.IPortableDevicePropVariantCollection.self) { pThis in
       var cElems: DWORD = DWORD(0)
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetCount(pThis, &cElems)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetCount(pThis, &cElems))
       return cElems
     }
   }
@@ -55,16 +52,14 @@ public class IPortableDevicePropVariantCollection: IUnknown {
   public func GetType() throws -> VARTYPE {
     return try perform(as: WinSDK.IPortableDevicePropVariantCollection.self) { pThis in
       var vt: VARTYPE = VARTYPE()
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetType(pThis, &vt)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetType(pThis, &vt))
       return vt
     }
   }
 
   public func RemoveAt(_ dwIndex: DWORD) throws {
     return try perform(as: WinSDK.IPortableDevicePropVariantCollection.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.RemoveAt(pThis, dwIndex)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveAt(pThis, dwIndex))
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IPortableDeviceValues.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IPortableDeviceValues.swift
@@ -12,26 +12,19 @@ public class IPortableDeviceValues: IUnknown {
 
   public func Clear() throws {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Clear(pThis)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Clear(pThis))
     }
   }
 
   public func CopyValuesFromPropertyStore(_ pStore: IPropertyStore) throws {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.CopyValuesFromPropertyStore(pThis,
-                                                                  RawPointer(pStore))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.CopyValuesFromPropertyStore(pThis, RawPointer(pStore)))
     }
   }
 
   public func CopyValuesToPropertyStore(_ pStore: IPropertyStore) throws {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.CopyValuesToPropertyStore(pThis,
-                                                                RawPointer(pStore))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.CopyValuesToPropertyStore(pThis, RawPointer(pStore)))
     }
   }
 
@@ -39,9 +32,7 @@ public class IPortableDeviceValues: IUnknown {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
       var Key: PROPERTYKEY = PROPERTYKEY()
       var Value: PROPVARIANT = PROPVARIANT()
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &Key, &Value)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &Key, &Value))
       return (Key, Value)
     }
   }
@@ -49,9 +40,7 @@ public class IPortableDeviceValues: IUnknown {
   public func GetBoolValue(_ key: REFPROPERTYKEY) throws -> Bool {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
       var Value: WindowsBool = false
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetBoolValue(pThis, key, &Value)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetBoolValue(pThis, key, &Value))
       return Value == true
     }
   }
@@ -60,11 +49,7 @@ public class IPortableDeviceValues: IUnknown {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
       var pValue: UnsafeMutablePointer<BYTE>?
       var cbValue: DWORD = DWORD(0)
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetBufferValue(pThis, key, &pValue,
-                                                      &cbValue)
-      guard hr == S_OK else { throw COMError(hr: hr) }
-
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetBufferValue(pThis, key, &pValue, &cbValue))
       defer { CoTaskMemFree(pValue) }
       return Array(UnsafeBufferPointer<BYTE>(start: pValue, count: Int(cbValue)))
     }
@@ -73,8 +58,7 @@ public class IPortableDeviceValues: IUnknown {
   public func GetCount() throws -> DWORD {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
       var celt: DWORD = DWORD(0)
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetCount(pThis, &celt)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetCount(pThis, &celt))
       return celt
     }
   }
@@ -82,9 +66,7 @@ public class IPortableDeviceValues: IUnknown {
   public func GetErrorValue(_ key: REFPROPERTYKEY) throws -> HRESULT {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
       var Value: HRESULT = S_OK
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetErrorValue(pThis, key, &Value)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetErrorValue(pThis, key, &Value))
       return Value
     }
   }
@@ -92,9 +74,7 @@ public class IPortableDeviceValues: IUnknown {
   public func GetFloatValue(_ key: REFPROPERTYKEY) throws -> FLOAT {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
       var Value: FLOAT = FLOAT()
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetFloatValue(pThis, key, &Value)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetFloatValue(pThis, key, &Value))
       return Value
     }
   }
@@ -102,9 +82,7 @@ public class IPortableDeviceValues: IUnknown {
   public func GetGuidValue(_ key: REFPROPERTYKEY) throws -> GUID {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
       var Value: GUID = GUID()
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetGuidValue(pThis, key, &Value)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetGuidValue(pThis, key, &Value))
       return Value
     }
   }
@@ -113,11 +91,7 @@ public class IPortableDeviceValues: IUnknown {
       throws -> IPortableDeviceKeyCollection {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
       var pValue: UnsafeMutablePointer<WinSDK.IPortableDeviceKeyCollection>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetIPortableDeviceKeyCollectionValue(pThis,
-                                                                            key,
-                                                                            &pValue)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetIPortableDeviceKeyCollectionValue(pThis, key, &pValue))
       return IPortableDeviceKeyCollection(pUnk: pValue)
     }
   }
@@ -126,11 +100,7 @@ public class IPortableDeviceValues: IUnknown {
       throws -> IPortableDevicePropVariantCollection {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
       var pValue: UnsafeMutablePointer<WinSDK.IPortableDevicePropVariantCollection>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetIPortableDevicePropVariantCollectionValue(pThis,
-                                                                                    key,
-                                                                                    &pValue)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetIPortableDevicePropVariantCollectionValue(pThis, key, &pValue))
       return IPortableDevicePropVariantCollection(pUnk: pValue)
     }
   }
@@ -139,11 +109,7 @@ public class IPortableDeviceValues: IUnknown {
       throws -> IPortableDeviceValuesCollection {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
       var pValue: UnsafeMutablePointer<WinSDK.IPortableDeviceValuesCollection>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetIPortableDeviceValuesCollectionValue(pThis,
-                                                                              key,
-                                                                              &pValue)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetIPortableDeviceValuesCollectionValue(pThis, key, &pValue))
       return IPortableDeviceValuesCollection(pUnk: pValue)
     }
   }
@@ -152,10 +118,7 @@ public class IPortableDeviceValues: IUnknown {
       throws -> IPortableDeviceValues {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
       var pValue: UnsafeMutablePointer<WinSDK.IPortableDeviceValues>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetIPortableDeviceValuesValue(pThis, key,
-                                                                    &pValue)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetIPortableDeviceValuesValue(pThis, key, &pValue))
       return IPortableDeviceValues(pUnk: pValue)
     }
   }
@@ -163,9 +126,7 @@ public class IPortableDeviceValues: IUnknown {
   public func GetIUnknownValue(_ key: REFPROPERTYKEY) throws -> IUnknown {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
       var pValue: UnsafeMutablePointer<WinSDK.IUnknown>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetIUnknownValue(pThis, key, &pValue)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetIUnknownValue(pThis, key, &pValue))
       return IUnknown(pUnk: pValue)
     }
   }
@@ -173,9 +134,7 @@ public class IPortableDeviceValues: IUnknown {
   public func GetKeyValue(_ key: REFPROPERTYKEY) throws -> PROPERTYKEY {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
       var Value: PROPERTYKEY = PROPERTYKEY()
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetKeyValue(pThis, key, &Value)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetKeyValue(pThis, key, &Value))
       return Value
     }
   }
@@ -183,9 +142,7 @@ public class IPortableDeviceValues: IUnknown {
   public func GetSignedIntegerValue(_ key: REFPROPERTYKEY) throws -> LONG {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
       var Value: LONG = LONG()
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetSignedIntegerValue(pThis, key, &Value)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetSignedIntegerValue(pThis, key, &Value))
       return Value
     }
   }
@@ -194,10 +151,7 @@ public class IPortableDeviceValues: IUnknown {
       throws -> LONGLONG {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
       var Value: LONGLONG = LONGLONG()
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetSignedLargeIntegerValue(pThis, key,
-                                                                  &Value)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetSignedLargeIntegerValue(pThis, key, &Value))
       return Value
     }
   }
@@ -205,10 +159,7 @@ public class IPortableDeviceValues: IUnknown {
   public func GetStringValue(_ key: REFPROPERTYKEY) throws -> String {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
       var Value: UnsafeMutablePointer<WCHAR>?
-      let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetStringValue(pThis, key, &Value)
-      guard hr == S_OK else { throw COMError(hr: hr) }
-
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetStringValue(pThis, key, &Value))
       defer { CoTaskMemFree(Value) }
       return String(decodingCString: Value!, as: UTF16.self)
     }
@@ -217,9 +168,7 @@ public class IPortableDeviceValues: IUnknown {
   public func GetUnsignedIntegerValue(_ key: REFPROPERTYKEY) throws -> ULONG {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
       var Value: ULONG = ULONG()
-      let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetUnsignedIntegerValue(pThis, key, &Value)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetUnsignedIntegerValue(pThis, key, &Value))
       return Value
     }
   }
@@ -228,10 +177,7 @@ public class IPortableDeviceValues: IUnknown {
       throws -> ULONGLONG {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
       var Value: ULONGLONG = ULONGLONG()
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetUnsignedLargeIntegerValue(pThis, key,
-                                                                    &Value)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetUnsignedLargeIntegerValue(pThis, key, &Value))
       return Value
     }
   }
@@ -239,59 +185,49 @@ public class IPortableDeviceValues: IUnknown {
   public func GetValue(_ key: REFPROPERTYKEY) throws -> PROPVARIANT {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
       var Value: PROPVARIANT = PROPVARIANT()
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetValue(pThis, key, &Value)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetValue(pThis, key, &Value))
       return Value
     }
   }
 
   public func RemoveValue(_ key: REFPROPERTYKEY) throws {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.RemoveValue(pThis, key)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveValue(pThis, key))
     }
   }
 
   public func SetBoolValue(_ key: REFPROPERTYKEY, _ value: WindowsBool) throws {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.SetBoolValue(pThis, key, value)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetBoolValue(pThis, key, value))
     }
   }
 
   public func SetBufferValue(_ key: REFPROPERTYKEY, _ value: [BYTE]) throws {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
       var value = value
-      let hr: HRESULT = value.withUnsafeMutableBufferPointer {
-        pThis.pointee.lpVtbl.pointee.SetBufferValue(pThis, key, $0.baseAddress,
-                                                    DWORD($0.count))
+      try CHECKED {
+        value.withUnsafeMutableBufferPointer {
+          pThis.pointee.lpVtbl.pointee.SetBufferValue(pThis, key, $0.baseAddress, DWORD($0.count))
+        }
       }
-      guard hr == S_OK else { throw COMError(hr: hr) }
     }
   }
 
   public func SetErrorValue(_ key: REFPROPERTYKEY, _ value: HRESULT) throws {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.SetErrorValue(pThis, key, value)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetErrorValue(pThis, key, value))
     }
   }
 
   public func SetFloatValue(_ key: REFPROPERTYKEY, _ value: FLOAT) throws {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.SetFloatValue(pThis, key, value)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetFloatValue(pThis, key, value))
     }
   }
 
   public func SetGuidValue(_ key: REFPROPERTYKEY, _ value: REFGUID) throws {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.SetGuidValue(pThis, key, value)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetGuidValue(pThis, key, value))
     }
   }
 
@@ -299,11 +235,7 @@ public class IPortableDeviceValues: IUnknown {
                                                    _ value: IPortableDeviceKeyCollection)
       throws {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.SetIPortableDeviceKeyCollectionValue(pThis,
-                                                                            key,
-                                                                            RawPointer(value))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetIPortableDeviceKeyCollectionValue(pThis, key, RawPointer(value)))
     }
   }
 
@@ -311,11 +243,7 @@ public class IPortableDeviceValues: IUnknown {
                                                            _ value: IPortableDevicePropVariantCollection)
       throws {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.SetIPortableDevicePropVariantCollectionValue(pThis,
-                                                                                    key,
-                                                                                    RawPointer(value))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetIPortableDevicePropVariantCollectionValue(pThis, key, RawPointer(value)))
     }
   }
 
@@ -323,11 +251,7 @@ public class IPortableDeviceValues: IUnknown {
                                                       _ value: IPortableDeviceValuesCollection)
       throws {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.SetIPortableDeviceValuesCollectionValue(pThis,
-                                                                              key,
-                                                                              RawPointer(value))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetIPortableDeviceValuesCollectionValue(pThis, key, RawPointer(value)))
     }
   }
 
@@ -335,85 +259,69 @@ public class IPortableDeviceValues: IUnknown {
                                             _ value: IPortableDeviceValues)
       throws {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.SetIPortableDeviceValuesValue(pThis,
-                                                                    key,
-                                                                    RawPointer(value))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetIPortableDeviceValuesValue(pThis, key, RawPointer(value)))
     }
   }
 
   public func SetIUnknownValue(_ key: REFPROPERTYKEY, _ value: IUnknown) throws {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.SetIUnknownValue(pThis, key,
-                                                        RawPointer(value))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetIUnknownValue(pThis, key, RawPointer(value)))
     }
   }
 
   public func SetKeyValue(_ key: REFPROPERTYKEY, _ value: REFPROPERTYKEY)
       throws {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.SetKeyValue(pThis, key, value)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetKeyValue(pThis, key, value))
     }
   }
 
   public func SetSignedIntegerValue(_ key: REFPROPERTYKEY, _ value: LONG)
       throws {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.SetSignedIntegerValue(pThis, key, value)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetSignedIntegerValue(pThis, key, value))
     }
   }
 
   public func SetSignedLargeIntegerValue(_ key: REFPROPERTYKEY,
                                          _ value: LONGLONG) throws {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.SetSignedLargeIntegerValue(pThis, key,
-                                                                  value)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetSignedLargeIntegerValue(pThis, key, value))
     }
   }
 
   public func SetStringValue(_ key: REFPROPERTYKEY, _ value: String) throws {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
-      let hr: HRESULT = value.withCString(encodedAs: UTF16.self) {
-        pThis.pointee.lpVtbl.pointee.SetStringValue(pThis, key, $0)
+      try CHECKED {
+        value.withCString(encodedAs: UTF16.self) {
+          pThis.pointee.lpVtbl.pointee.SetStringValue(pThis, key, $0)
+        }
       }
-      guard hr == S_OK else { throw COMError(hr: hr) }
     }
   }
 
   public func SetUnsignedIntegerValue(_ key: REFPROPERTYKEY, _ value: ULONG)
       throws {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.SetUnsignedIntegerValue(pThis, key, value)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetUnsignedIntegerValue(pThis, key, value))
     }
   }
 
   public func SetUnsignedLargeIntegerValue(_ key: REFPROPERTYKEY,
                                            _ value: ULONGLONG) throws {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.SetUnsignedLargeIntegerValue(pThis, key,
-                                                                    value)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetUnsignedLargeIntegerValue(pThis, key, value))
     }
   }
 
   public func SetValue(_ key: REFPROPERTYKEY, _ value: PROPVARIANT) throws {
     return try perform(as: WinSDK.IPortableDeviceValues.self) { pThis in
       var value = value
-      let hr: HRESULT = withUnsafePointer(to: &value) {
-        pThis.pointee.lpVtbl.pointee.SetValue(pThis, key, $0)
+      try CHECKED {
+        withUnsafePointer(to: &value) {
+          pThis.pointee.lpVtbl.pointee.SetValue(pThis, key, $0)
+        }
       }
-      guard hr == S_OK else { throw COMError(hr: hr) }
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IPortableDeviceValuesCollection.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IPortableDeviceValuesCollection.swift
@@ -12,25 +12,20 @@ public class IPortableDeviceValuesCollection: IUnknown {
 
   public func Add(_ pValues: IPortableDeviceValues) throws {
     return try perform(as: WinSDK.IPortableDeviceValuesCollection.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.Add(pThis, RawPointer(pValues))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Add(pThis, RawPointer(pValues)))
     }
   }
 
   public func Clear() throws {
     return try perform(as: WinSDK.IPortableDeviceValuesCollection.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Clear(pThis)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Clear(pThis))
     }
   }
 
   public func GetAt(_ dwIndex: DWORD) throws -> IPortableDeviceValues {
     return try perform(as: WinSDK.IPortableDeviceValuesCollection.self) { pThis in
       var pValues: UnsafeMutablePointer<WinSDK.IPortableDeviceValues>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetAt(pThis, dwIndex, &pValues)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, dwIndex, &pValues))
       return IPortableDeviceValues(pUnk: pValues)
     }
   }
@@ -38,16 +33,14 @@ public class IPortableDeviceValuesCollection: IUnknown {
   public func GetCount() throws -> DWORD {
     return try perform(as: WinSDK.IPortableDeviceValuesCollection.self) { pThis in
       var cElems: DWORD = DWORD(0)
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetCount(pThis, &cElems)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetCount(pThis, &cElems))
       return cElems
     }
   }
 
   public func RemoveAt(_ dwIndex: DWORD) throws {
     return try perform(as: WinSDK.IPortableDeviceValuesCollection.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.RemoveAt(pThis, dwIndex)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveAt(pThis, dwIndex))
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IPropertyChange.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IPropertyChange.swift
@@ -14,10 +14,7 @@ public class IPropertyChange: IObjectWithPropertyKey {
       throws -> PROPVARIANT {
     return try perform(as: WinSDK.IPropertyChange.self) { pThis in
       var propvarOut: PROPVARIANT = PROPVARIANT()
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.ApplyToPropVariant(pThis, propvarIn,
-                                                          &propvarOut)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.ApplyToPropVariant(pThis, propvarIn, &propvarOut))
       return propvarOut
     }
   }

--- a/Sources/SwiftCOM/Interfaces/Human/IPropertyChangeArray.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IPropertyChangeArray.swift
@@ -12,18 +12,13 @@ public class IPropertyChangeArray: IUnknown {
 
   public func Append(_ ppropChange: IPropertyChange) throws {
     return try perform(as: WinSDK.IPropertyChangeArray.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.Append(pThis, RawPointer(ppropChange))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Append(pThis, RawPointer(ppropChange)))
     }
   }
 
   public func AppendOrReplace(_ ppropChange: IPropertyChange) throws {
     return try perform(as: WinSDK.IPropertyChangeArray.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.AppendOrReplace(pThis,
-                                                      RawPointer(ppropChange))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.AppendOrReplace(pThis, RawPointer(ppropChange)))
     }
   }
 
@@ -31,9 +26,7 @@ public class IPropertyChangeArray: IUnknown {
       throws -> IUnknown {
     return try perform(as: WinSDK.IPropertyChangeArray.self) { pThis in
       var pv: UnsafeMutableRawPointer?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetAt(pThis, iIndex, &riid, &pv)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, iIndex, &riid, &pv))
       return IUnknown(pUnk: pv)
     }
   }
@@ -41,18 +34,14 @@ public class IPropertyChangeArray: IUnknown {
   public func GetCount() throws -> UINT {
     return try perform(as: WinSDK.IPropertyChangeArray.self) { pThis in
       var cOperations: UINT = 0
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetCount(pThis, &cOperations)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetCount(pThis, &cOperations))
       return cOperations
     }
   }
 
   public func InsertAt(_ iIndex: UINT, _ ppropChange: IPropertyChange) throws {
     return try perform(as: WinSDK.IPropertyChangeArray.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.InsertAt(pThis, iIndex,
-                                                RawPointer(ppropChange))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.InsertAt(pThis, iIndex, RawPointer(ppropChange)))
     }
   }
 
@@ -69,8 +58,7 @@ public class IPropertyChangeArray: IUnknown {
 
   public func RemoveAt(_ iIndex: UINT) throws {
     return try perform(as: WinSDK.IPropertyChangeArray.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.RemoveAt(pThis, iIndex)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveAt(pThis, iIndex))
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IPropertyStore.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IPropertyStore.swift
@@ -12,16 +12,14 @@ public class IPropertyStore: IUnknown {
 
   public func Commit() throws {
     return try perform(as: WinSDK.IPropertyStore.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Commit(pThis)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Commit(pThis))
     }
   }
 
   public func GetAt(_ iProp: DWORD) throws -> PROPERTYKEY {
     return try perform(as: WinSDK.IPropertyStore.self) { pThis in
       var Key: PROPERTYKEY = PROPERTYKEY()
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetAt(pThis, iProp, &Key)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, iProp, &Key))
       return Key
     }
   }
@@ -29,8 +27,7 @@ public class IPropertyStore: IUnknown {
   public func GetCount() throws -> DWORD {
     return try perform(as: WinSDK.IPropertyStore.self) { pThis in
       var cProps: DWORD = DWORD(0)
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetCount(pThis, &cProps)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetCount(pThis, &cProps))
       return cProps
     }
   }
@@ -38,16 +35,14 @@ public class IPropertyStore: IUnknown {
   public func GetValue(_ key: REFPROPERTYKEY) throws -> PROPVARIANT {
     return try perform(as: WinSDK.IPropertyStore.self) { pThis in
       var v: PROPVARIANT = PROPVARIANT()
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetValue(pThis, key, &v)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetValue(pThis, key, &v))
       return v
     }
   }
 
   public func GetValue(_ key: REFPROPERTYKEY, _ propvar: REFPROPVARIANT) throws {
     return try perform(as: WinSDK.IPropertyStore.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.SetValue(pThis, key, propvar)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetValue(pThis, key, propvar))
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IRunningObjectTable.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IRunningObjectTable.swift
@@ -13,9 +13,7 @@ public class IRunningObjectTable: IUnknown {
   public func EnumRunning() throws -> IEnumMoniker {
     return try perform(as: WinSDK.IRunningObjectTable.self) { pThis in
       var penumMoniker: UnsafeMutablePointer<WinSDK.IEnumMoniker>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.EnumRunning(pThis, &penumMoniker)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.EnumRunning(pThis, &penumMoniker))
       return IEnumMoniker(pUnk: penumMoniker)
     }
   }
@@ -26,10 +24,7 @@ public class IRunningObjectTable: IUnknown {
       // FIXME(compnerd) GetObject is also a free function which has a unicode and
       // ascii version. As a result, `GetObject` is a macro which happens to
       // expand incorrectly to `GetObjectA` here.
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetObjectA(pThis, RawPointer(pmkObjectName),
-                                                  &punkObject)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetObjectA(pThis, RawPointer(pmkObjectName), &punkObject))
       return IUnknown(pUnk: punkObject)
     }
   }
@@ -37,27 +32,21 @@ public class IRunningObjectTable: IUnknown {
   public func GetTimeOfLastChange(_ pmkObjectName: IMoniker) throws -> FILETIME {
     return try perform(as: WinSDK.IRunningObjectTable.self) { pThis in
       var filetime: FILETIME = FILETIME()
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee
-                            .GetTimeOfLastChange(pThis, RawPointer(pmkObjectName),
-                                                &filetime)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetTimeOfLastChange(pThis, RawPointer(pmkObjectName), &filetime))
       return filetime
     }
   }
 
   public func IsRunning(_ pmkObjectName: IMoniker) throws -> Bool {
     return try perform(as: WinSDK.IRunningObjectTable.self) { pThis in
-      return pThis.pointee.lpVtbl.pointee.IsRunning(pThis,
-                                                    RawPointer(pmkObjectName)) == S_OK
+      return pThis.pointee.lpVtbl.pointee.IsRunning(pThis, RawPointer(pmkObjectName)) == S_OK
     }
   }
 
   public func NoteChangeTime(_ dwRegister: DWORD) throws -> FILETIME {
     return try perform(as: WinSDK.IRunningObjectTable.self) { pThis in
       var filetime: FILETIME = FILETIME()
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.NoteChangeTime(pThis, dwRegister, &filetime)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.NoteChangeTime(pThis, dwRegister, &filetime))
       return filetime
     }
   }
@@ -66,20 +55,14 @@ public class IRunningObjectTable: IUnknown {
                        _ pmkObjectName: IMoniker) throws -> DWORD {
     return try perform(as: WinSDK.IRunningObjectTable.self) { pThis in
       var dwRegister: DWORD = 0
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.Register(pThis, grfFlags, punkObject.pUnk,
-                                                RawPointer(pmkObjectName),
-                                                &dwRegister)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Register(pThis, grfFlags, punkObject.pUnk, RawPointer(pmkObjectName), &dwRegister))
       return dwRegister
     }
   }
 
   public func Revoke(_ dwRegister: DWORD) throws {
     return try perform(as: WinSDK.IRunningObjectTable.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.Revoke(pThis, dwRegister)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Revoke(pThis, dwRegister))
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/ISensor.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ISensor.swift
@@ -13,9 +13,7 @@ public class ISensor: IUnknown {
   public func GetCategory() throws -> SENSOR_CATEGORY_ID {
     return try perform(as: WinSDK.ISensor.self) { pThis in
       var SensorCategory: SENSOR_CATEGORY_ID = SENSOR_CATEGORY_ID()
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetCategory(pThis, &SensorCategory)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetCategory(pThis, &SensorCategory))
       return SensorCategory
     }
   }
@@ -23,8 +21,7 @@ public class ISensor: IUnknown {
   public func GetData() throws -> ISensorDataReport {
     return try perform(as: WinSDK.ISensor.self) { pThis in
       var pDataReport: UnsafeMutablePointer<WinSDK.ISensorDataReport>?
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetData(pThis, &pDataReport)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetData(pThis, &pDataReport))
       return ISensorDataReport(pUnk: pDataReport)
     }
   }
@@ -33,9 +30,7 @@ public class ISensor: IUnknown {
     return try perform(as: WinSDK.ISensor.self) { pThis in
       var pValues: UnsafeMutablePointer<GUID>?
       var Count: ULONG = ULONG()
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetEventInterest(pThis, &pValues, &Count)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetEventInterest(pThis, &pValues, &Count))
       return Array(UnsafeBufferPointer<GUID>(start: pValues, count: Int(Count)))
     }
   }
@@ -43,9 +38,7 @@ public class ISensor: IUnknown {
   public func GetFriendlyName() throws -> String {
     return try perform(as: WinSDK.ISensor.self) { pThis in
       var FriendlyName: BSTR?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetFriendlyName(pThis, &FriendlyName)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetFriendlyName(pThis, &FriendlyName))
       defer { SysFreeString(FriendlyName) }
       return FriendlyName == nil ? "" : String(from: FriendlyName!)
     }
@@ -54,8 +47,7 @@ public class ISensor: IUnknown {
   public func GetID() throws -> SENSOR_ID {
     return try perform(as: WinSDK.ISensor.self) { pThis in
       var ID: SENSOR_ID = SENSOR_ID()
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetID(pThis, &ID)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetID(pThis, &ID))
       return ID
     }
   }
@@ -64,10 +56,7 @@ public class ISensor: IUnknown {
       throws -> IPortableDeviceValues {
     return try perform(as: WinSDK.ISensor.self) { pThis in
       var pProperties: UnsafeMutablePointer<WinSDK.IPortableDeviceValues>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetProperties(pThis, RawPointer(Keys),
-                                                    &pProperties)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetProperties(pThis, RawPointer(Keys), &pProperties))
       return IPortableDeviceValues(pUnk: pProperties)
     }
   }
@@ -75,9 +64,7 @@ public class ISensor: IUnknown {
   public func GetProperty(_ key: REFPROPERTYKEY) throws -> PROPVARIANT {
     return try perform(as: WinSDK.ISensor.self) { pThis in
       var Property: PROPVARIANT = PROPVARIANT()
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetProperty(pThis, key, &Property)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetProperty(pThis, key, &Property))
       return Property
     }
   }
@@ -85,8 +72,7 @@ public class ISensor: IUnknown {
   public func GetState() throws -> SensorState {
     return try perform(as: WinSDK.ISensor.self) { pThis in
       var State: SensorState = SensorState(0)
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetState(pThis, &State)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetState(pThis, &State))
       return State
     }
   }
@@ -94,9 +80,7 @@ public class ISensor: IUnknown {
   public func GetSupportedDataFields() throws -> IPortableDeviceKeyCollection {
     return try perform(as: WinSDK.ISensor.self) { pThis in
       var pDataFields: UnsafeMutablePointer<WinSDK.IPortableDeviceKeyCollection>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetSupportedDataFields(pThis, &pDataFields)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetSupportedDataFields(pThis, &pDataFields))
       return IPortableDeviceKeyCollection(pUnk: pDataFields)
     }
   }
@@ -104,8 +88,7 @@ public class ISensor: IUnknown {
   public func GetType() throws -> SENSOR_TYPE_ID {
     return try perform(as: WinSDK.ISensor.self) { pThis in
       var SensorType: SENSOR_TYPE_ID = SENSOR_TYPE_ID()
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetType(pThis, &SensorType)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetType(pThis, &SensorType))
       return SensorType
     }
   }
@@ -113,19 +96,17 @@ public class ISensor: IUnknown {
   public func SetEventInterest(_ Values: [GUID]) throws {
     return try perform(as: WinSDK.ISensor.self) { pThis in
       var Values = Values
-      let hr: HRESULT = Values.withUnsafeMutableBufferPointer {
-        pThis.pointee.lpVtbl.pointee.SetEventInterest(pThis, $0.baseAddress,
-                                                      ULONG($0.count))
+      try CHECKED {
+        Values.withUnsafeMutableBufferPointer {
+          pThis.pointee.lpVtbl.pointee.SetEventInterest(pThis, $0.baseAddress, ULONG($0.count))
+        }
       }
-      guard hr == S_OK else { throw COMError(hr: hr) }
     }
   }
 
   public func SetEventSink(_ pEvents: ISensorEvents?) throws {
     return try perform(as: WinSDK.ISensor.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.SetEventSink(pThis, RawPointer(pEvents))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetEventSink(pThis, RawPointer(pEvents)))
     }
   }
 
@@ -133,10 +114,7 @@ public class ISensor: IUnknown {
       throws -> IPortableDeviceValues {
     return try perform(as: WinSDK.ISensor.self) { pThis in
       var pResults: UnsafeMutablePointer<WinSDK.IPortableDeviceValues>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.SetProperties(pThis, RawPointer(pProperties),
-                                                    &pResults)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetProperties(pThis, RawPointer(pProperties), &pResults))
       return IPortableDeviceValues(pUnk: pResults)
     }
   }
@@ -144,9 +122,7 @@ public class ISensor: IUnknown {
   public func SupportsDataField(_ key: REFPROPERTYKEY) throws -> Bool {
     return try perform(as: WinSDK.ISensor.self) { pThis in
       var IsSupported: VARIANT_BOOL = VARIANT_BOOL()
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.SupportsDataField(pThis, key, &IsSupported)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SupportsDataField(pThis, key, &IsSupported))
       return IsSupported == VARIANT_TRUE
     }
   }
@@ -154,10 +130,7 @@ public class ISensor: IUnknown {
   public func SupportsEvent(_ eventGuid: REFGUID) throws -> Bool {
     return try perform(as: WinSDK.ISensor.self) { pThis in
       var IsSupported: VARIANT_BOOL = VARIANT_BOOL()
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.SupportsEvent(pThis, eventGuid,
-                                                    &IsSupported)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SupportsEvent(pThis, eventGuid, &IsSupported))
       return IsSupported == VARIANT_TRUE
     }
   }

--- a/Sources/SwiftCOM/Interfaces/Human/ISensorCollection.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ISensorCollection.swift
@@ -12,25 +12,20 @@ public class ISensorCollection: IUnknown {
 
   public func Add(_ pSensor: ISensor) throws {
     return try perform(as: WinSDK.ISensorCollection.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.Add(pThis, RawPointer(pSensor))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Add(pThis, RawPointer(pSensor)))
     }
   }
 
   public func Clear() throws {
     return try perform(as: WinSDK.ISensorCollection.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Clear(pThis)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Clear(pThis))
     }
   }
 
   public func GetAt(_ ulIndex: ULONG) throws -> ISensor {
     return try perform(as: WinSDK.ISensorCollection.self) { pThis in
       var pSensor: UnsafeMutablePointer<WinSDK.ISensor>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetAt(pThis, ulIndex, &pSensor)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, ulIndex, &pSensor))
       return ISensor(pUnk: pSensor)
     }
   }
@@ -38,24 +33,20 @@ public class ISensorCollection: IUnknown {
   public func GetCount() throws -> ULONG {
     return try perform(as: WinSDK.ISensorCollection.self) { pThis in
       var Count: ULONG = ULONG(0)
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetCount(pThis, &Count)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetCount(pThis, &Count))
       return Count
     }
   }
 
   public func Remove(_ pSensor: ISensor) throws {
     return try perform(as: WinSDK.ISensorCollection.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.Remove(pThis, RawPointer(pSensor))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Remove(pThis, RawPointer(pSensor)))
     }
   }
 
   public func RemoveByID(_ sensorID: REFSENSOR_ID) throws {
     return try perform(as: WinSDK.ISensorCollection.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.RemoveByID(pThis, sensorID)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveByID(pThis, sensorID))
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/ISensorDataReport.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ISensorDataReport.swift
@@ -13,9 +13,7 @@ public class ISensorDataReport: IUnknown {
   public func GetSensorValue(_ pKey: REFPROPERTYKEY) throws -> PROPVARIANT {
     return try perform(as: WinSDK.ISensorDataReport.self) { pThis in
       var Value: PROPVARIANT = PROPVARIANT()
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetSensorValue(pThis, pKey, &Value)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetSensorValue(pThis, pKey, &Value))
       return Value
     }
   }
@@ -24,10 +22,7 @@ public class ISensorDataReport: IUnknown {
       throws -> IPortableDeviceValues {
     return try perform(as: WinSDK.ISensorDataReport.self) { pThis in
       var pValues: UnsafeMutablePointer<WinSDK.IPortableDeviceValues>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetSensorValues(pThis, RawPointer(pKeys),
-                                                       &pValues)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetSensorValues(pThis, RawPointer(pKeys), &pValues))
       return IPortableDeviceValues(pUnk: pValues)
     }
   }
@@ -35,9 +30,7 @@ public class ISensorDataReport: IUnknown {
   public func GetTimestamp() throws -> SYSTEMTIME {
     return try perform(as: WinSDK.ISensorDataReport.self) { pThis in
       var TimeStamp: SYSTEMTIME = SYSTEMTIME()
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetTimestamp(pThis, &TimeStamp)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetTimestamp(pThis, &TimeStamp))
       return TimeStamp
     }
   }

--- a/Sources/SwiftCOM/Interfaces/Human/ISensorManager.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ISensorManager.swift
@@ -13,9 +13,7 @@ public class ISensorManager: IUnknown {
   public func GetSensorByID(_ sensorID: REFSENSOR_ID) throws -> ISensor {
     return try perform(as: WinSDK.ISensorManager.self) { pThis in
       var pSensor: UnsafeMutablePointer<WinSDK.ISensor>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetSensorByID(pThis, sensorID, &pSensor)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetSensorByID(pThis, sensorID, &pSensor))
       return ISensor(pUnk: pSensor)
     }
   }
@@ -24,10 +22,7 @@ public class ISensorManager: IUnknown {
       throws -> ISensorCollection {
     return try perform(as: WinSDK.ISensorManager.self) { pThis in
       var pSensorsFound: UnsafeMutablePointer<WinSDK.ISensorCollection>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetSensorsByCategory(pThis, sensorCategory,
-                                                            &pSensorsFound)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetSensorsByCategory(pThis, sensorCategory, &pSensorsFound))
       return ISensorCollection(pUnk: pSensorsFound)
     }
   }
@@ -36,10 +31,7 @@ public class ISensorManager: IUnknown {
       throws -> ISensorCollection {
     return try perform(as: WinSDK.ISensorManager.self) { pThis in
       var pSensorsFound: UnsafeMutablePointer<WinSDK.ISensorCollection>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetSensorsByType(pThis, sensorType,
-                                                        &pSensorsFound)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetSensorsByType(pThis, sensorType, &pSensorsFound))
       return ISensorCollection(pUnk: pSensorsFound)
     }
   }
@@ -48,19 +40,13 @@ public class ISensorManager: IUnknown {
                                  _ pSensors: ISensorCollection?, _ fModal: Bool)
       throws {
     return try perform(as: WinSDK.ISensorManager.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.RequestPermissions(pThis, hParent,
-                                                          RawPointer(pSensors),
-                                                          WindowsBool(fModal))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.RequestPermissions(pThis, hParent, RawPointer(pSensors), WindowsBool(fModal)))
     }
   }
 
   public func SetEventSink(_ pEvents: ISensorManagerEvents?) throws {
     return try perform(as: WinSDK.ISensorManager.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.SetEventSink(pThis, RawPointer(pEvents))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetEventSink(pThis, RawPointer(pEvents)))
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IShellItem.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IShellItem.swift
@@ -14,10 +14,7 @@ public class IShellItem: IUnknown {
                             _ riid: inout IID) throws -> IUnknown {
     return try perform(as: WinSDK.IShellItem.self) { pThis in
       var pv: UnsafeMutableRawPointer?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.BindToHandler(pThis, RawPointer(pbc),
-                                                    &bhid, &riid, &pv)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.BindToHandler(pThis, RawPointer(pbc), &bhid, &riid, &pv))
       return IUnknown(pUnk: pv)
     }
   }
@@ -25,10 +22,7 @@ public class IShellItem: IUnknown {
   public func Compare(_ psi: IShellItem, _ hint: SICHINTF) throws -> CInt {
     return try perform(as: WinSDK.IShellItem.self) { pThis in
       var iOrder: CInt = 0
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.Compare(pThis, RawPointer(psi), hint,
-                                              &iOrder)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Compare(pThis, RawPointer(psi), hint, &iOrder))
       return iOrder
     }
   }
@@ -36,10 +30,7 @@ public class IShellItem: IUnknown {
   public func GetAttributes(_ sfgaoMask: SFGAOF) throws -> SFGAOF {
     return try perform(as: WinSDK.IShellItem.self) { pThis in
       var sfgaoAttribs: SFGAOF = SFGAOF()
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetAttributes(pThis, sfgaoMask,
-                                                    &sfgaoAttribs)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetAttributes(pThis, sfgaoMask, &sfgaoAttribs))
       return sfgaoAttribs
     }
   }
@@ -47,9 +38,7 @@ public class IShellItem: IUnknown {
   public func GetDisplayName(_ sigdnName: SIGDN) throws -> String {
     return try perform(as: WinSDK.IShellItem.self) { pThis in
       var pszName: LPWSTR?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetDisplayName(pThis, sigdnName, &pszName)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetDisplayName(pThis, sigdnName, &pszName))
       defer { CoTaskMemFree(pszName) }
       return String(decodingCString: pszName!, as: UTF16.self)
     }
@@ -58,8 +47,7 @@ public class IShellItem: IUnknown {
   public func GetParent() throws -> IShellItem {
     return try perform(as: WinSDK.IShellItem.self) { pThis in
       var psi: UnsafeMutablePointer<WinSDK.IShellItem>?
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetParent(pThis, &psi)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetParent(pThis, &psi))
       return IShellItem(pUnk: psi)
     }
   }

--- a/Sources/SwiftCOM/Interfaces/Human/IStream.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IStream.swift
@@ -13,16 +13,14 @@ public class IStream: IUnknown {
   public func Clone() throws -> IStream {
     return try perform(as: WinSDK.IStream.self) { pThis in
       var pstm: UnsafeMutablePointer<WinSDK.IStream>?
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Clone(pThis, &pstm)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Clone(pThis, &pstm))
       return IStream(pUnk: pstm)
     }
   }
 
   public func Commit(_ grfCommitFlags: DWORD) throws {
     return try perform(as: WinSDK.IStream.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Commit(pThis, grfCommitFlags)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Commit(pThis, grfCommitFlags))
     }
   }
 
@@ -31,10 +29,7 @@ public class IStream: IUnknown {
     return try perform(as: WinSDK.IStream.self) { pThis in
       var cbRead: ULARGE_INTEGER = ULARGE_INTEGER()
       var cbWritten: ULARGE_INTEGER = ULARGE_INTEGER()
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.CopyTo(pThis, RawPointer(pstm), cb,
-                                              &cbRead, &cbWritten)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.CopyTo(pThis, RawPointer(pstm), cb, &cbRead, &cbWritten))
       return (cbRead, cbWritten)
     }
   }
@@ -42,16 +37,13 @@ public class IStream: IUnknown {
   public func LockRegion(_ libOffset: ULARGE_INTEGER, _ cb: ULARGE_INTEGER,
                          _ dwLockType: DWORD) throws {
     return try perform(as: WinSDK.IStream.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.LockRegion(pThis, libOffset, cb, dwLockType)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.LockRegion(pThis, libOffset, cb, dwLockType))
     }
   }
 
   public func Revert() throws {
     return try perform(as: WinSDK.IStream.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Revert(pThis)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Revert(pThis))
     }
   }
 
@@ -59,27 +51,21 @@ public class IStream: IUnknown {
       throws -> ULARGE_INTEGER {
     return try perform(as: WinSDK.IStream.self) { pThis in
       var libNewPosition: ULARGE_INTEGER = ULARGE_INTEGER()
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.Seek(pThis, dlibMove, dwOrigin,
-                                            &libNewPosition)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Seek(pThis, dlibMove, dwOrigin, &libNewPosition))
       return libNewPosition
     }
   }
 
   public func SetSize(_ libNewSize: ULARGE_INTEGER) throws {
     return try perform(as: WinSDK.IStream.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.SetSize(pThis, libNewSize)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetSize(pThis, libNewSize))
     }
   }
 
   public func Stat(_ grfStatFlag: DWORD) throws -> STATSTG {
     return try perform(as: WinSDK.IStream.self) { pThis in
       var statstg: STATSTG = STATSTG()
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.Stat(pThis, &statstg, grfStatFlag)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Stat(pThis, &statstg, grfStatFlag))
       return statstg
     }
   }
@@ -87,10 +73,7 @@ public class IStream: IUnknown {
   public func UnlockRegion(_ libOffset: ULARGE_INTEGER, _ cb: ULARGE_INTEGER,
                            _ dwLockType: DWORD) throws {
     return try perform(as: WinSDK.IStream.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.UnlockRegion(pThis, libOffset, cb,
-                                                    dwLockType)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.UnlockRegion(pThis, libOffset, cb, dwLockType))
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmap.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmap.swift
@@ -14,27 +14,24 @@ public class IWICBitmap: IWICBitmapSource {
     return try perform(as: WinSDK.IWICBitmap.self) { pThis in
       var rcLock = rcLock
       var pILock: UnsafeMutablePointer<WinSDK.IWICBitmapLock>?
-      let hr: HRESULT = withUnsafePointer(to: &rcLock) {
-        pThis.pointee.lpVtbl.pointee.Lock(pThis, $0, flags, &pILock)
+      try CHECKED {
+        withUnsafePointer(to: &rcLock) {
+          pThis.pointee.lpVtbl.pointee.Lock(pThis, $0, flags, &pILock)
+        }
       }
-      guard hr == S_OK else { throw COMError(hr: hr) }
       return IWICBitmapLock(pUnk: pILock)
     }
   }
 
   public func SetPalette(_ pIPalette: IWICPalette) throws {
     return try perform(as: WinSDK.IWICBitmap.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.SetPalette(pThis, RawPointer(pIPalette))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetPalette(pThis, RawPointer(pIPalette)))
     }
   }
 
   public func SetResolution(_ dpiX: Double, _ dpiY: Double) throws {
     return try perform(as: WinSDK.IWICBitmap.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.SetResolution(pThis, dpiX, dpiY)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetResolution(pThis, dpiX, dpiY))
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapClipper.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapClipper.swift
@@ -13,10 +13,7 @@ public class IWICBitmapClipper: IWICBitmapSource {
   public func Initialize(_ pISource: IWICBitmapSource, _ rc: WICRect) throws {
     return try perform(as: WinSDK.IWICBitmapClipper.self) { pThis in
       var rc = rc
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.Initialize(pThis, RawPointer(pISource),
-                                                  &rc)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Initialize(pThis, RawPointer(pISource), &rc))
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapCodecInfo.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapCodecInfo.swift
@@ -13,10 +13,7 @@ public class IWICBitmapCodecInfo: IWICComponentInfo {
   public func DoesSupportAnimation() throws -> Bool {
     return try perform(as: WinSDK.IWICBitmapCodecInfo.self) { pThis in
       var fSupportAnimation: WindowsBool = false
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.DoesSupportAnimation(pThis,
-                                                            &fSupportAnimation)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.DoesSupportAnimation(pThis, &fSupportAnimation))
       return fSupportAnimation == true
     }
   }
@@ -24,10 +21,7 @@ public class IWICBitmapCodecInfo: IWICComponentInfo {
   public func DoesSupportChromakey() throws -> Bool {
     return try perform(as: WinSDK.IWICBitmapCodecInfo.self) { pThis in
       var fSupportChromakey: WindowsBool = false
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.DoesSupportChromakey(pThis,
-                                                            &fSupportChromakey)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.DoesSupportChromakey(pThis, &fSupportChromakey))
       return fSupportChromakey == true
     }
   }
@@ -35,10 +29,7 @@ public class IWICBitmapCodecInfo: IWICComponentInfo {
   public func DoesSupportLossless() throws -> Bool {
     return try perform(as: WinSDK.IWICBitmapCodecInfo.self) { pThis in
       var fSupportLossless: WindowsBool = false
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.DoesSupportLossless(pThis,
-                                                          &fSupportLossless)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.DoesSupportLossless(pThis, &fSupportLossless))
       return fSupportLossless == true
     }
   }
@@ -46,10 +37,7 @@ public class IWICBitmapCodecInfo: IWICComponentInfo {
   public func DoesSupportMultiframe() throws -> Bool {
     return try perform(as: WinSDK.IWICBitmapCodecInfo.self) { pThis in
       var fSupportMultiframe: WindowsBool = false
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.DoesSupportMultiframe(pThis,
-                                                            &fSupportMultiframe)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.DoesSupportMultiframe(pThis, &fSupportMultiframe))
       return fSupportMultiframe == true
     }
   }
@@ -57,19 +45,11 @@ public class IWICBitmapCodecInfo: IWICComponentInfo {
   public func GetColorManagementVersion() throws -> String {
     return try perform(as: WinSDK.IWICBitmapCodecInfo.self) { pThis in
       var cchActual: UINT = UINT(0)
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetColorManagementVersion(pThis, 0, nil,
-                                                                &cchActual)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetColorManagementVersion(pThis, 0, nil, &cchActual))
 
       let buffer: [WCHAR] =
           try Array<WCHAR>(unsafeUninitializedCapacity: Int(cchActual)) {
-        let hr: HRESULT =
-            pThis.pointee.lpVtbl.pointee.GetColorManagementVersion(pThis,
-                                                                  UINT($0.count),
-                                                                  $0.baseAddress,
-                                                                  &cchActual)
-        guard hr == S_OK else { throw COMError(hr: hr) }
+        try CHECKED(pThis.pointee.lpVtbl.pointee.GetColorManagementVersion(pThis, UINT($0.count), $0.baseAddress, &cchActual))
         $1 = Int(cchActual)
       }
       return String(decoding: buffer, as: UTF16.self)
@@ -79,10 +59,7 @@ public class IWICBitmapCodecInfo: IWICComponentInfo {
   public func GetContainerFormat() throws -> GUID {
     return try perform(as: WinSDK.IWICBitmapCodecInfo.self) { pThis in
       var guidContainerFromat: GUID = GUID()
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetContainerFormat(pThis,
-                                                          &guidContainerFromat)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetContainerFormat(pThis, &guidContainerFromat))
       return guidContainerFromat
     }
   }
@@ -90,19 +67,11 @@ public class IWICBitmapCodecInfo: IWICComponentInfo {
   public func GetDeviceManufacturer() throws -> String {
     return try perform(as: WinSDK.IWICBitmapCodecInfo.self) { pThis in
       var cchActual: UINT = UINT(0)
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetDeviceManufacturer(pThis, 0, nil,
-                                                            &cchActual)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetDeviceManufacturer(pThis, 0, nil, &cchActual))
 
       let buffer: [WCHAR] =
           try Array<WCHAR>(unsafeUninitializedCapacity: Int(cchActual)) {
-        let hr: HRESULT =
-            pThis.pointee.lpVtbl.pointee.GetDeviceManufacturer(pThis,
-                                                              UINT($0.count),
-                                                              $0.baseAddress,
-                                                              &cchActual)
-        guard hr == S_OK else { throw COMError(hr: hr) }
+        try CHECKED(pThis.pointee.lpVtbl.pointee.GetDeviceManufacturer(pThis, UINT($0.count), $0.baseAddress, &cchActual))
         $1 = Int(cchActual)
       }
       return String(decoding: buffer, as: UTF16.self)
@@ -112,17 +81,11 @@ public class IWICBitmapCodecInfo: IWICComponentInfo {
   public func GetDeviceModels() throws -> String {
     return try perform(as: WinSDK.IWICBitmapCodecInfo.self) { pThis in
       var cchActual: UINT = UINT(0)
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetDeviceModels(pThis, 0, nil, &cchActual)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetDeviceModels(pThis, 0, nil, &cchActual))
 
       let buffer: [WCHAR] =
           try Array<WCHAR>(unsafeUninitializedCapacity: Int(cchActual)) {
-        let hr: HRESULT =
-            pThis.pointee.lpVtbl.pointee.GetDeviceModels(pThis, UINT($0.count),
-                                                        $0.baseAddress,
-                                                        &cchActual)
-        guard hr == S_OK else { throw COMError(hr: hr) }
+        try CHECKED(pThis.pointee.lpVtbl.pointee.GetDeviceModels(pThis, UINT($0.count), $0.baseAddress, &cchActual))
         $1 = Int(cchActual)
       }
       return String(decoding: buffer, as: UTF16.self)
@@ -132,17 +95,11 @@ public class IWICBitmapCodecInfo: IWICComponentInfo {
   public func GetFileExtensions() throws -> String {
     return try perform(as: WinSDK.IWICBitmapCodecInfo.self) { pThis in
       var cchActual: UINT = UINT(0)
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetFileExtensions(pThis, 0, nil, &cchActual)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetFileExtensions(pThis, 0, nil, &cchActual))
 
       let buffer: [WCHAR] =
           try Array<WCHAR>(unsafeUninitializedCapacity: Int(cchActual)) {
-        let hr: HRESULT =
-            pThis.pointee.lpVtbl.pointee.GetFileExtensions(pThis, UINT($0.count),
-                                                          $0.baseAddress,
-                                                          &cchActual)
-        guard hr == S_OK else { throw COMError(hr: hr) }
+        try CHECKED(pThis.pointee.lpVtbl.pointee.GetFileExtensions(pThis, UINT($0.count), $0.baseAddress, &cchActual))
         $1 = Int(cchActual)
       }
       return String(decoding: buffer, as: UTF16.self)
@@ -152,16 +109,11 @@ public class IWICBitmapCodecInfo: IWICComponentInfo {
   public func GetMimeTypes() throws -> String {
     return try perform(as: WinSDK.IWICBitmapCodecInfo.self) { pThis in
       var cchActual: UINT = UINT(0)
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetMimeTypes(pThis, 0, nil, &cchActual)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetMimeTypes(pThis, 0, nil, &cchActual))
 
       let buffer: [WCHAR] =
           try Array<WCHAR>(unsafeUninitializedCapacity: Int(cchActual)) {
-        let hr: HRESULT =
-            pThis.pointee.lpVtbl.pointee.GetMimeTypes(pThis, UINT($0.count),
-                                                      $0.baseAddress, &cchActual)
-        guard hr == S_OK else { throw COMError(hr: hr) }
+        try CHECKED(pThis.pointee.lpVtbl.pointee.GetMimeTypes(pThis, UINT($0.count), $0.baseAddress, &cchActual))
         $1 = Int(cchActual)
       }
       return String(decoding: buffer, as: UTF16.self)
@@ -171,15 +123,10 @@ public class IWICBitmapCodecInfo: IWICComponentInfo {
   public func GetPixelFormats() throws -> [GUID] {
     return try perform(as: WinSDK.IWICBitmapCodecInfo.self) { pThis in
       var cActual: UINT = UINT(0)
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetPixelFormats(pThis, 0, nil, &cActual)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetPixelFormats(pThis, 0, nil, &cActual))
 
       return try Array<GUID>(unsafeUninitializedCapacity: Int(cActual)) {
-        let hr: HRESULT =
-            pThis.pointee.lpVtbl.pointee.GetPixelFormats(pThis, UINT($0.count),
-                                                        $0.baseAddress, &cActual)
-        guard hr == S_OK else { throw COMError(hr: hr) }
+        try CHECKED(pThis.pointee.lpVtbl.pointee.GetPixelFormats(pThis, UINT($0.count), $0.baseAddress, &cActual))
         $1 = Int(cActual)
       }
     }
@@ -188,10 +135,11 @@ public class IWICBitmapCodecInfo: IWICComponentInfo {
   public func MatchesMimeType(_ szMimeType: String) throws -> Bool {
     return try perform(as: WinSDK.IWICBitmapCodecInfo.self) { pThis in
       var fMatches: WindowsBool = false
-      let hr: HRESULT = szMimeType.withCString(encodedAs: UTF16.self) {
-        pThis.pointee.lpVtbl.pointee.MatchesMimeType(pThis, $0, &fMatches)
+      try CHECKED {
+        szMimeType.withCString(encodedAs: UTF16.self) {
+          pThis.pointee.lpVtbl.pointee.MatchesMimeType(pThis, $0, &fMatches)
+        }
       }
-      guard hr == S_OK else { throw COMError(hr: hr) }
       return fMatches == true
     }
   }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapDecoder.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapDecoder.swift
@@ -12,27 +12,18 @@ public class IWICBitmapDecoder: IUnknown {
 
   public func CopyPalette(_ pIPalette: IWICPalette) throws {
     return try perform(as: WinSDK.IWICBitmapDecoder.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.CopyPalette(pThis, RawPointer(pIPalette))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.CopyPalette(pThis, RawPointer(pIPalette)))
     }
   }
 
   public func GetColorContexts() throws -> [IWICColorContext] {
     return try perform(as: WinSDK.IWICBitmapDecoder.self) { pThis in
       var cActualCount: UINT = UINT(0)
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetColorContexts(pThis, 0, nil,
-                                                        &cActualCount)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetColorContexts(pThis, 0, nil, &cActualCount))
 
       let contexts: [UnsafeMutablePointer<WinSDK.IWICColorContext>?] =
           try .init(unsafeUninitializedCapacity: Int(cActualCount)) {
-        let hr: HRESULT =
-            pThis.pointee.lpVtbl.pointee.GetColorContexts(pThis, cActualCount,
-                                                          $0.baseAddress,
-                                                          &cActualCount)
-        guard hr == S_OK else { throw COMError(hr: hr) }
+        try CHECKED(pThis.pointee.lpVtbl.pointee.GetColorContexts(pThis, cActualCount, $0.baseAddress, &cActualCount))
         $1 = Int(cActualCount)
       }
 
@@ -43,11 +34,7 @@ public class IWICBitmapDecoder: IUnknown {
   public func GetContainerFormat() throws -> GUID {
     return try perform(as: WinSDK.IWICBitmapDecoder.self) { pThis in
       var guidContainerFormat: GUID = GUID()
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetContainerFormat(pThis,
-                                                          &guidContainerFormat)
-      guard hr == S_OK else { throw COMError(hr: hr) }
-
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetContainerFormat(pThis, &guidContainerFormat))
       return guidContainerFormat
     }
   }
@@ -55,10 +42,7 @@ public class IWICBitmapDecoder: IUnknown {
   public func GetDecoderInfo() throws -> IWICBitmapDecoderInfo {
     return try perform(as: WinSDK.IWICBitmapDecoder.self) { pThis in
       var pIDecoderInfo: UnsafeMutablePointer<WinSDK.IWICBitmapDecoderInfo>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetDecoderInfo(pThis, &pIDecoderInfo)
-      guard hr == S_OK else { throw COMError(hr: hr) }
-
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetDecoderInfo(pThis, &pIDecoderInfo))
       return IWICBitmapDecoderInfo(pUnk: pIDecoderInfo)
     }
   }
@@ -66,10 +50,7 @@ public class IWICBitmapDecoder: IUnknown {
   public func GetFrame(_ index: UINT) throws -> IWICBitmapFrameDecode {
     return try perform(as: WinSDK.IWICBitmapDecoder.self) { pThis in
       var pIBitmapFrame: UnsafeMutablePointer<WinSDK.IWICBitmapFrameDecode>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetFrame(pThis, index, &pIBitmapFrame)
-      guard hr == S_OK else { throw COMError(hr: hr) }
-
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetFrame(pThis, index, &pIBitmapFrame))
       return IWICBitmapFrameDecode(pUnk: pIBitmapFrame)
     }
   }
@@ -77,9 +58,7 @@ public class IWICBitmapDecoder: IUnknown {
   public func GetFrameCount() throws -> UINT {
     return try perform(as: WinSDK.IWICBitmapDecoder.self) { pThis in
       var Count: UINT = UINT(0)
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetFrameCount(pThis, &Count)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetFrameCount(pThis, &Count))
       return Count
     }
   }
@@ -87,11 +66,7 @@ public class IWICBitmapDecoder: IUnknown {
   public func GetMetadataQueryReader() throws -> IWICMetadataQueryReader {
     return try perform(as: WinSDK.IWICBitmapDecoder.self) { pThis in
       var pIMetadataQueryReader: UnsafeMutablePointer<WinSDK.IWICMetadataQueryReader>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetMetadataQueryReader(pThis,
-                                                              &pIMetadataQueryReader)
-      guard hr == S_OK else { throw COMError(hr: hr) }
-
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetMetadataQueryReader(pThis, &pIMetadataQueryReader))
       return IWICMetadataQueryReader(pUnk: pIMetadataQueryReader)
     }
   }
@@ -99,10 +74,7 @@ public class IWICBitmapDecoder: IUnknown {
   public func GetPreview() throws -> IWICBitmapSource {
     return try perform(as: WinSDK.IWICBitmapDecoder.self) { pThis in
       var pIBitmapSource: UnsafeMutablePointer<WinSDK.IWICBitmapSource>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetPreview(pThis, &pIBitmapSource)
-      guard hr == S_OK else { throw COMError(hr: hr) }
-
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetPreview(pThis, &pIBitmapSource))
       return IWICBitmapSource(pUnk: pIBitmapSource)
     }
   }
@@ -110,10 +82,7 @@ public class IWICBitmapDecoder: IUnknown {
   public func GetThumbnail() throws -> IWICBitmapSource {
     return try perform(as: WinSDK.IWICBitmapDecoder.self) { pThis in
       var pIBitmapSource: UnsafeMutablePointer<WinSDK.IWICBitmapSource>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetThumbnail(pThis, &pIBitmapSource)
-      guard hr == S_OK else { throw COMError(hr: hr) }
-
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetThumbnail(pThis, &pIBitmapSource))
       return IWICBitmapSource(pUnk: pIBitmapSource)
     }
   }
@@ -121,20 +90,14 @@ public class IWICBitmapDecoder: IUnknown {
   public func Initialize(_ pStream: IStream,
                          _ cacheOptions: WICDecodeOptions) throws {
     return try perform(as: WinSDK.IWICBitmapDecoder.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.Initialize(pThis, RawPointer(pStream),
-                                                  cacheOptions)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Initialize(pThis, RawPointer(pStream), cacheOptions))
     }
   }
 
   public func QueryCapability(_ pStream: IStream) throws -> DWORD {
     return try perform(as: WinSDK.IWICBitmapDecoder.self) { pThis in
       var dwCapability: DWORD = DWORD(0)
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.QueryCapability(pThis, RawPointer(pStream),
-                                                      &dwCapability)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.QueryCapability(pThis, RawPointer(pStream), &dwCapability))
       return dwCapability
     }
   }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapDecoderInfo.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapDecoderInfo.swift
@@ -13,9 +13,7 @@ public class IWICBitmapDecoderInfo: IWICBitmapCodecInfo {
   public func CreateInstance() throws -> IWICBitmapDecoder {
     return try perform(as: WinSDK.IWICBitmapDecoderInfo.self) { pThis in
       var pIBitmapDecoder: UnsafeMutablePointer<WinSDK.IWICBitmapDecoder>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.CreateInstance(pThis, &pIBitmapDecoder)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.CreateInstance(pThis, &pIBitmapDecoder))
       return IWICBitmapDecoder(pUnk: pIBitmapDecoder)
     }
   }
@@ -24,17 +22,10 @@ public class IWICBitmapDecoderInfo: IWICBitmapCodecInfo {
     return try perform(as: WinSDK.IWICBitmapDecoderInfo.self) { pThis in
       var cPatterns: UINT = UINT(0)
       var cbPatternsActual: UINT = UINT(0)
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetPatterns(pThis, 0, nil, &cPatterns,
-                                                  &cbPatternsActual)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetPatterns(pThis, 0, nil, &cPatterns, &cbPatternsActual))
 
       return try Array<WICBitmapPattern>(unsafeUninitializedCapacity: Int(cPatterns)) {
-        let hr: HRESULT =
-            pThis.pointee.lpVtbl.pointee.GetPatterns(pThis, UINT($0.count),
-                                                    $0.baseAddress, &cPatterns,
-                                                    &cbPatternsActual)
-        guard hr == S_OK else { throw COMError(hr: hr) }
+        try CHECKED(pThis.pointee.lpVtbl.pointee.GetPatterns(pThis, UINT($0.count), $0.baseAddress, &cPatterns, &cbPatternsActual))
         $1 = Int(cPatterns)
       }
     }
@@ -43,10 +34,7 @@ public class IWICBitmapDecoderInfo: IWICBitmapCodecInfo {
   public func MatchesPattern(_ pIStream: IStream) throws -> Bool {
     return try perform(as: WinSDK.IWICBitmapDecoderInfo.self) { pThis in
       var fMatches: WindowsBool = false
-      let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.MatchesPattern(pThis, RawPointer(pIStream),
-                                                    &fMatches)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.MatchesPattern(pThis, RawPointer(pIStream), &fMatches))
       return fMatches == true
     }
   }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapEncoder.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapEncoder.swift
@@ -12,8 +12,7 @@ public class IWICBitmapEncoder: IUnknown {
 
   public func Commit() throws {
     return try perform(as: WinSDK.IWICBitmapEncoder.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Commit(pThis)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Commit(pThis))
     }
   }
 
@@ -21,10 +20,7 @@ public class IWICBitmapEncoder: IUnknown {
     return try perform(as: WinSDK.IWICBitmapEncoder.self) { pThis in
       var pIFrameEncode: UnsafeMutablePointer<WinSDK.IWICBitmapFrameEncode>?
       var pIEncoderOptions: UnsafeMutablePointer<WinSDK.IPropertyBag2>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.CreateNewFrame(pThis, &pIFrameEncode,
-                                                      &pIEncoderOptions)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.CreateNewFrame(pThis, &pIFrameEncode, &pIEncoderOptions))
       return (IWICBitmapFrameEncode(pUnk: pIFrameEncode),
               IPropertyBag2(pUnk: pIEncoderOptions))
     }
@@ -33,10 +29,7 @@ public class IWICBitmapEncoder: IUnknown {
   public func GetContainerFormat() throws -> GUID {
     return try perform(as: WinSDK.IWICBitmapEncoder.self) { pThis in
       var guidContainerFormat: GUID = GUID()
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetContainerFormat(pThis,
-                                                          &guidContainerFormat)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetContainerFormat(pThis, &guidContainerFormat))
       return guidContainerFormat
     }
   }
@@ -44,9 +37,7 @@ public class IWICBitmapEncoder: IUnknown {
   public func GetEncoderInfo() throws -> IWICBitmapEncoderInfo {
     return try perform(as: WinSDK.IWICBitmapEncoder.self) { pThis in
       var pIEncoderInfo: UnsafeMutablePointer<WinSDK.IWICBitmapEncoderInfo>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetEncoderInfo(pThis, &pIEncoderInfo)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetEncoderInfo(pThis, &pIEncoderInfo))
       return IWICBitmapEncoderInfo(pUnk: pIEncoderInfo)
     }
   }
@@ -54,10 +45,7 @@ public class IWICBitmapEncoder: IUnknown {
   public func GetMetadataQueryWriter() throws -> IWICMetadataQueryWriter {
     return try perform(as: WinSDK.IWICBitmapEncoder.self) { pThis in
       var pIMetadataQueryWriter: UnsafeMutablePointer<WinSDK.IWICMetadataQueryWriter>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetMetadataQueryWriter(pThis,
-                                                              &pIMetadataQueryWriter)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetMetadataQueryWriter(pThis, &pIMetadataQueryWriter))
       return IWICMetadataQueryWriter(pUnk: pIMetadataQueryWriter)
     }
   }
@@ -66,10 +54,7 @@ public class IWICBitmapEncoder: IUnknown {
                          _ cacheOption: WICBitmapEncoderCacheOption)
       throws {
     return try perform(as: WinSDK.IWICBitmapEncoder.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.Initialize(pThis, RawPointer(pIStream),
-                                                  cacheOption)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Initialize(pThis, RawPointer(pIStream), cacheOption))
     }
   }
 
@@ -77,35 +62,29 @@ public class IWICBitmapEncoder: IUnknown {
     return try perform(as: WinSDK.IWICBitmapEncoder.self) { pThis in
       var pointers: [UnsafeMutablePointer<WinSDK.IWICColorContext>?] =
           contexts.map { RawPointer($0) }
-      let hr: HRESULT = pointers.withUnsafeMutableBufferPointer {
-        pThis.pointee.lpVtbl.pointee.SetColorContexts(pThis, UINT($0.count),
-                                                      $0.baseAddress)
+      try CHECKED {
+        pointers.withUnsafeMutableBufferPointer {
+          pThis.pointee.lpVtbl.pointee.SetColorContexts(pThis, UINT($0.count), $0.baseAddress)
+        }
       }
-      guard hr == S_OK else { throw COMError(hr: hr) }
     }
   }
 
   public func SetPalette(_ pIPalette: IWICPalette) throws {
     return try perform(as: WinSDK.IWICBitmapEncoder.self) { pThis in
-      let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetPalette(pThis, RawPointer(pIPalette))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetPalette(pThis, RawPointer(pIPalette)))
     }
   }
 
   public func SetPreview(_ pIPreview: IWICBitmapSource) throws {
     return try perform(as: WinSDK.IWICBitmapEncoder.self) { pThis in
-      let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetPreview(pThis, RawPointer(pIPreview))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetPreview(pThis, RawPointer(pIPreview)))
     }
   }
 
   public func SetThumbnail(_ pIThumbnail: IWICBitmapSource) throws {
     return try perform(as: WinSDK.IWICBitmapEncoder.self) { pThis in
-      let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.SetThumbnail(pThis, RawPointer(pIThumbnail))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetThumbnail(pThis, RawPointer(pIThumbnail)))
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapEncoderInfo.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapEncoderInfo.swift
@@ -13,9 +13,7 @@ public class IWICBitmapEncoderInfo: IWICBitmapCodecInfo {
   public func CreateInstance() throws -> IWICBitmapEncoder {
     return try perform(as: WinSDK.IWICBitmapEncoderInfo.self) { pThis in
       var pIBitmapEncoder: UnsafeMutablePointer<WinSDK.IWICBitmapEncoder>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.CreateInstance(pThis, &pIBitmapEncoder)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.CreateInstance(pThis, &pIBitmapEncoder))
       return IWICBitmapEncoder(pUnk: pIBitmapEncoder)
     }
   }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapFlipRotator.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapFlipRotator.swift
@@ -13,10 +13,7 @@ public class IWICBitmapFlipRotator: IWICBitmapSource {
   public func Initialize(_ pISource: IWICBitmapSource,
                          _ options: WICBitmapTransformOptions) throws {
     return try perform(as: WinSDK.IWICBitmapFlipRotator.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.Initialize(pThis, RawPointer(pISource),
-                                                  options)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Initialize(pThis, RawPointer(pISource), options))
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapFrameDecode.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapFrameDecode.swift
@@ -13,18 +13,11 @@ public class IWICBitmapFrameDecode: IWICBitmapSource {
   public func GetColorContexts() throws -> [IWICColorContext] {
     return try perform(as: WinSDK.IWICBitmapFrameDecode.self) { pThis in
       var cActualCount: UINT = UINT(0)
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetColorContexts(pThis, 0, nil,
-                                                        &cActualCount)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetColorContexts(pThis, 0, nil, &cActualCount))
 
       let contexts: [UnsafeMutablePointer<WinSDK.IWICColorContext>?] =
           try .init(unsafeUninitializedCapacity: Int(cActualCount)) {
-        let hr: HRESULT =
-            pThis.pointee.lpVtbl.pointee.GetColorContexts(pThis, cActualCount,
-                                                          $0.baseAddress,
-                                                          &cActualCount)
-        guard hr == S_OK else { throw COMError(hr: hr) }
+        try CHECKED(pThis.pointee.lpVtbl.pointee.GetColorContexts(pThis, cActualCount, $0.baseAddress, &cActualCount))
         $1 = Int(cActualCount)
       }
 
@@ -35,10 +28,7 @@ public class IWICBitmapFrameDecode: IWICBitmapSource {
   public func GetMetadataQueryReader() throws -> IWICMetadataQueryReader {
     return try perform(as: WinSDK.IWICBitmapFrameDecode.self) { pThis in
       var pIMetadataQueryReader: UnsafeMutablePointer<WinSDK.IWICMetadataQueryReader>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetMetadataQueryReader(pThis,
-                                                              &pIMetadataQueryReader)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetMetadataQueryReader(pThis, &pIMetadataQueryReader))
       return IWICMetadataQueryReader(pUnk: pIMetadataQueryReader)
     }
   }
@@ -46,10 +36,7 @@ public class IWICBitmapFrameDecode: IWICBitmapSource {
   public func GetThumbnail() throws -> IWICBitmapSource {
     return try perform(as: WinSDK.IWICBitmapFrameDecode.self) { pThis in
       var pIBitmapSource: UnsafeMutablePointer<WinSDK.IWICBitmapSource>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetThumbnail(pThis, &pIBitmapSource)
-      guard hr == S_OK else { throw COMError(hr: hr) }
-
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetThumbnail(pThis, &pIBitmapSource))
       return IWICBitmapSource(pUnk: pIBitmapSource)
     }
   }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapFrameEncode.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapFrameEncode.swift
@@ -12,28 +12,21 @@ public class IWICBitmapFrameEncode: IUnknown {
 
   public func Commit() throws {
     return try perform(as: WinSDK.IWICBitmapFrameEncode.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Commit(pThis)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Commit(pThis))
     }
   }
 
   public func GetMetadataQueryWriter() throws -> IWICMetadataQueryWriter {
     return try perform(as: WinSDK.IWICBitmapFrameEncode.self) { pThis in
       var pIMetadataQueryWriter: UnsafeMutablePointer<WinSDK.IWICMetadataQueryWriter>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetMetadataQueryWriter(pThis,
-                                                              &pIMetadataQueryWriter)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetMetadataQueryWriter(pThis, &pIMetadataQueryWriter))
       return IWICMetadataQueryWriter(pUnk: pIMetadataQueryWriter)
     }
   }
 
   public func Initialize(_ pIEncoderOptions: IPropertyBag2) throws {
     return try perform(as: WinSDK.IWICBitmapFrameEncode.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.Initialize(pThis,
-                                                  RawPointer(pIEncoderOptions))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Initialize(pThis, RawPointer(pIEncoderOptions)))
     }
   }
 
@@ -41,72 +34,61 @@ public class IWICBitmapFrameEncode: IUnknown {
     return try perform(as: WinSDK.IWICBitmapFrameEncode.self) { pThis in
       var pointers: [UnsafeMutablePointer<WinSDK.IWICColorContext>?] =
           contexts.map { RawPointer($0) }
-      let hr: HRESULT = pointers.withUnsafeMutableBufferPointer {
-        pThis.pointee.lpVtbl.pointee.SetColorContexts(pThis, UINT($0.count),
-                                                      $0.baseAddress)
+      try CHECKED {
+        pointers.withUnsafeMutableBufferPointer {
+          pThis.pointee.lpVtbl.pointee.SetColorContexts(pThis, UINT($0.count), $0.baseAddress)
+        }
       }
-      guard hr == S_OK else { throw COMError(hr: hr) }
     }
   }
 
   public func SetPalette(_ pIPalette: IWICPalette) throws {
     return try perform(as: WinSDK.IWICBitmapFrameEncode.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.SetPalette(pThis, RawPointer(pIPalette))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetPalette(pThis, RawPointer(pIPalette)))
     }
   }
 
   public func SetPixelFormat(_ pPixelFormat: inout WICPixelFormatGUID) throws {
     return try perform(as: WinSDK.IWICBitmapFrameEncode.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.SetPixelFormat(pThis, &pPixelFormat)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetPixelFormat(pThis, &pPixelFormat))
     }
   }
 
   public func SetResolution(_ dpiX: Double, _ dpiY: Double) throws {
     return try perform(as: WinSDK.IWICBitmapFrameEncode.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.SetResolution(pThis, dpiX, dpiY)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetResolution(pThis, dpiX, dpiY))
     }
   }
 
   public func SetSize(_ uiWidth: UINT, _ uiHeight: UINT) throws {
     return try perform(as: WinSDK.IWICBitmapFrameEncode.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.SetSize(pThis, uiWidth, uiHeight)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetSize(pThis, uiWidth, uiHeight))
     }
   }
 
   public func SetThumbnail(_ pIThumbnail: IWICBitmapSource) throws {
     return try perform(as: WinSDK.IWICBitmapFrameEncode.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.SetThumbnail(pThis,
-                                                    RawPointer(pIThumbnail))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetThumbnail(pThis, RawPointer(pIThumbnail)))
     }
   }
 
   public func WritePixels(_ lineCount: UINT, _ cbStride: UINT, _ pixels: inout [BYTE]) throws {
     return try perform(as: WinSDK.IWICBitmapFrameEncode.self) { pThis in
-      let hr: HRESULT = pixels.withUnsafeMutableBufferPointer {
-        pThis.pointee.lpVtbl.pointee.WritePixels(pThis, lineCount, cbStride,
-                                                UINT($0.count), $0.baseAddress)
+      try CHECKED {
+        pixels.withUnsafeMutableBufferPointer {
+          pThis.pointee.lpVtbl.pointee.WritePixels(pThis, lineCount, cbStride, UINT($0.count), $0.baseAddress)
+        }
       }
-      guard hr == S_OK else { throw COMError(hr: hr) }
     }
   }
 
   public func WriteSource(_ pIBitmapSource: IWICBitmapSource, _ rc: inout WICRect) throws {
     return try perform(as: WinSDK.IWICBitmapFrameEncode.self) { pThis in
-      let hr: HRESULT = withUnsafeMutablePointer(to: &rc) {
-        pThis.pointee.lpVtbl.pointee.WriteSource(pThis,
-                                                RawPointer(pIBitmapSource), $0)
+      try CHECKED {
+        withUnsafeMutablePointer(to: &rc) {
+          pThis.pointee.lpVtbl.pointee.WriteSource(pThis, RawPointer(pIBitmapSource), $0)
+        }
       }
-      guard hr == S_OK else { throw COMError(hr: hr) }
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapLock.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapLock.swift
@@ -14,10 +14,7 @@ public class IWICBitmapLock: IUnknown {
     return try perform(as: WinSDK.IWICBitmapLock.self) { pThis in
       var cbBufferSize: UINT = UINT(0)
       var pbData: WICInProcPointer?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetDataPointer(pThis, &cbBufferSize,
-                                                      &pbData)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetDataPointer(pThis, &cbBufferSize, &pbData))
       return Array<BYTE>(UnsafeBufferPointer<BYTE>(start: pbData,
                                                   count: Int(cbBufferSize)))
     }
@@ -26,9 +23,7 @@ public class IWICBitmapLock: IUnknown {
   public func GetPixelFormat() throws -> WICPixelFormatGUID {
     return try perform(as: WinSDK.IWICBitmapLock.self) { pThis in
       var PixelFormat: WICPixelFormatGUID = WICPixelFormatGUID()
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetPixelFormat(pThis, &PixelFormat)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetPixelFormat(pThis, &PixelFormat))
       return PixelFormat
     }
   }
@@ -37,9 +32,7 @@ public class IWICBitmapLock: IUnknown {
     return try perform(as: WinSDK.IWICBitmapLock.self) { pThis in
       var uiWidth: UINT = UINT(0)
       var uiHeight: UINT = UINT(0)
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetSize(pThis, &uiWidth, &uiHeight)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetSize(pThis, &uiWidth, &uiHeight))
       return (uiWidth, uiHeight)
     }
   }
@@ -47,8 +40,7 @@ public class IWICBitmapLock: IUnknown {
   public func GetStride() throws -> UINT {
     return try perform(as: WinSDK.IWICBitmapLock.self) { pThis in
       var cbStride: UINT = UINT(0)
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetStride(pThis, &cbStride)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetStride(pThis, &cbStride))
       return cbStride
     }
   }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapScaler.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapScaler.swift
@@ -14,10 +14,7 @@ public class IWICBitmapScaler: IWICBitmapSource {
                          _ uiHeight: UINT,
                          _ mode: WICBitmapInterpolationMode) throws {
     return try perform(as: WinSDK.IWICBitmapScaler.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.Initialize(pThis, RawPointer(pISource),
-                                                  uiWidth, uiHeight, mode)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Initialize(pThis, RawPointer(pISource), uiWidth, uiHeight, mode))
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapSource.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapSource.swift
@@ -12,35 +12,25 @@ public class IWICBitmapSource: IUnknown {
 
   public func CopyPalette(_ pIPalette: IWICPalette) throws {
     return try perform(as: WinSDK.IWICBitmapSource.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.CopyPalette(pThis, RawPointer(pIPalette))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.CopyPalette(pThis, RawPointer(pIPalette)))
     }
   }
 
   public func CopyPixels(_ rc: WICRect?, _ cbStride: UINT,
                          _ pbBuffer: UnsafeMutableBufferPointer<BYTE>) throws {
     return try perform(as: WinSDK.IWICBitmapSource.self) { pThis in
-      let hr: HRESULT
       if var rc = rc {
-        hr = pThis.pointee.lpVtbl.pointee.CopyPixels(pThis, &rc, cbStride,
-                                                     UINT(pbBuffer.count),
-                                                     pbBuffer.baseAddress)
+        try CHECKED(pThis.pointee.lpVtbl.pointee.CopyPixels(pThis, &rc, cbStride, UINT(pbBuffer.count), pbBuffer.baseAddress))
       } else {
-        hr = pThis.pointee.lpVtbl.pointee.CopyPixels(pThis, nil, cbStride,
-                                                     UINT(pbBuffer.count),
-                                                     pbBuffer.baseAddress)
+        try CHECKED(pThis.pointee.lpVtbl.pointee.CopyPixels(pThis, nil, cbStride, UINT(pbBuffer.count), pbBuffer.baseAddress))
       }
-      guard hr == S_OK else { throw COMError(hr: hr) }
     }
   }
 
   public func GetPixelFormat() throws -> WICPixelFormatGUID {
     return try perform(as: WinSDK.IWICBitmapSource.self) { pThis in
       var PixelFormat: WICPixelFormatGUID = WICPixelFormatGUID()
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetPixelFormat(pThis, &PixelFormat)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetPixelFormat(pThis, &PixelFormat))
       return PixelFormat
     }
   }
@@ -49,9 +39,7 @@ public class IWICBitmapSource: IUnknown {
     return try perform(as: WinSDK.IWICBitmapSource.self) { pThis in
       var DpiX: Double = 0.0
       var DpiY: Double = 0.0
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetResolution(pThis, &DpiX, &DpiY)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetResolution(pThis, &DpiX, &DpiY))
       return (DpiX, DpiY)
     }
   }
@@ -60,9 +48,7 @@ public class IWICBitmapSource: IUnknown {
     return try perform(as: WinSDK.IWICBitmapSource.self) { pThis in
       var uiWidth: UINT = UINT(0)
       var uiHeight: UINT = UINT(0)
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetSize(pThis, &uiWidth, &uiHeight)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetSize(pThis, &uiWidth, &uiHeight))
       return (uiWidth, uiHeight)
     }
   }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICColorContext.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICColorContext.swift
@@ -13,9 +13,7 @@ public class IWICColorContext: IUnknown {
   public func GetExifColorSpace() throws -> UINT {
     return try perform(as: WinSDK.IWICColorContext.self) { pThis in
       var Value: UINT = UINT(0)
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetExifColorSpace(pThis, &Value)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetExifColorSpace(pThis, &Value))
       return Value
     }
   }
@@ -23,15 +21,10 @@ public class IWICColorContext: IUnknown {
   public func GetProfileBytes() throws -> [BYTE] {
     return try perform(as: WinSDK.IWICColorContext.self) { pThis in
       var cbActual: UINT = UINT(0)
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetProfileBytes(pThis, 0, nil, &cbActual)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetProfileBytes(pThis, 0, nil, &cbActual))
 
       return try Array<BYTE>(unsafeUninitializedCapacity: Int(cbActual)) {
-        let hr: HRESULT =
-            pThis.pointee.lpVtbl.pointee.GetProfileBytes(pThis, UINT($0.count),
-                                                        $0.baseAddress, &cbActual)
-        guard hr == S_OK else { throw COMError(hr: hr) }
+        try CHECKED(pThis.pointee.lpVtbl.pointee.GetProfileBytes(pThis, UINT($0.count), $0.baseAddress, &cbActual))
         $1 = Int(cbActual)
       }
     }
@@ -40,36 +33,34 @@ public class IWICColorContext: IUnknown {
   public func GetType() throws -> WICColorContextType {
     return try perform(as: WinSDK.IWICColorContext.self) { pThis in
       var Type: WICColorContextType = WICColorContextType(0)
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetType(pThis, &Type)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetType(pThis, &Type))
       return Type
     }
   }
 
   public func InitializeFromExifColorSpace(_ value: UINT) throws {
     return try perform(as: WinSDK.IWICColorContext.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.InitializeFromExifColorSpace(pThis, value)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.InitializeFromExifColorSpace(pThis, value))
     }
   }
 
   public func InitializeFromFilename(_ filename: String) throws {
     return try perform(as: WinSDK.IWICColorContext.self) { pThis in
-      let hr: HRESULT = filename.withCString(encodedAs: UTF16.self) {
-        pThis.pointee.lpVtbl.pointee.InitializeFromFilename(pThis, $0)
+      try CHECKED {
+        filename.withCString(encodedAs: UTF16.self) {
+          pThis.pointee.lpVtbl.pointee.InitializeFromFilename(pThis, $0)
+        }
       }
-      guard hr == S_OK else { throw COMError(hr: hr) }
     }
   }
 
   public func InitializeFromMemory(_ pbBuffer: [BYTE]) throws {
     return try perform(as: WinSDK.IWICColorContext.self) { pThis in
-      let hr: HRESULT = pbBuffer.withUnsafeBufferPointer {
-        pThis.pointee.lpVtbl.pointee.InitializeFromMemory(pThis, $0.baseAddress,
-                                                          UINT($0.count))
+      try CHECKED {
+        pbBuffer.withUnsafeBufferPointer {
+          pThis.pointee.lpVtbl.pointee.InitializeFromMemory(pThis, $0.baseAddress, UINT($0.count))
+        }
       }
-      guard hr == S_OK else { throw COMError(hr: hr) }
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICColorTransform.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICColorTransform.swift
@@ -15,12 +15,7 @@ public class IWICColorTransform: IWICBitmapSource {
                          _ pIContextDest: IWICColorContext,
                          _ pixelFmtDest: REFWICPixelFormatGUID) throws {
     return try perform(as: WinSDK.IWICColorTransform.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.Initialize(pThis, RawPointer(pISource),
-                                                  RawPointer(pIContextSource),
-                                                  RawPointer(pIContextDest),
-                                                  pixelFmtDest)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Initialize(pThis, RawPointer(pISource), RawPointer(pIContextSource), RawPointer(pIContextDest), pixelFmtDest))
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICComponentInfo.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICComponentInfo.swift
@@ -13,18 +13,13 @@ public class IWICComponentInfo: IUnknown {
   public func GetAuthor() throws -> String? {
     return try perform(as: WinSDK.IWICComponentInfo.self) { pThis in
       var cchActual: UINT = UINT(0)
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetAuthor(pThis, 0, nil, &cchActual)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetAuthor(pThis, 0, nil, &cchActual))
 
       guard cchActual > 0 else { return nil }
 
       let buffer: [WCHAR] =
           try Array<WCHAR>(unsafeUninitializedCapacity: Int(cchActual)) {
-        let hr: HRESULT =
-            pThis.pointee.lpVtbl.pointee.GetAuthor(pThis, UINT($0.count),
-                                                  $0.baseAddress, &cchActual)
-        guard hr == S_OK else { throw COMError(hr: hr) }
+        try CHECKED(pThis.pointee.lpVtbl.pointee.GetAuthor(pThis, UINT($0.count), $0.baseAddress, &cchActual))
         $1 = Int(cchActual)
       }
       return String(decoding: buffer, as: UTF16.self)
@@ -34,8 +29,7 @@ public class IWICComponentInfo: IUnknown {
   public func GetCLSID() throws -> CLSID {
     return try perform(as: WinSDK.IWICComponentInfo.self) { pThis in
       var clsid: CLSID = CLSID()
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetCLSID(pThis, &clsid)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetCLSID(pThis, &clsid))
       return clsid
     }
   }
@@ -43,8 +37,7 @@ public class IWICComponentInfo: IUnknown {
   public func GetComponentType() throws -> WICComponentType {
     return try perform(as: WinSDK.IWICComponentInfo.self) { pThis in
       var Type: WICComponentType = WICComponentType(0)
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetComponentType(pThis, &Type)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetComponentType(pThis, &Type))
       return Type
     }
   }
@@ -52,17 +45,11 @@ public class IWICComponentInfo: IUnknown {
   public func GetFriendlyName() throws -> String {
     return try perform(as: WinSDK.IWICComponentInfo.self) { pThis in
       var cchActual: UINT = UINT(0)
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetFriendlyName(pThis, 0, nil, &cchActual)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetFriendlyName(pThis, 0, nil, &cchActual))
 
       let buffer: [WCHAR] =
           try Array<WCHAR>(unsafeUninitializedCapacity: Int(cchActual)) {
-        let hr: HRESULT =
-            pThis.pointee.lpVtbl.pointee.GetFriendlyName(pThis, UINT($0.count),
-                                                        $0.baseAddress,
-                                                        &cchActual)
-        guard hr == S_OK else { throw COMError(hr: hr) }
+        try CHECKED(pThis.pointee.lpVtbl.pointee.GetFriendlyName(pThis, UINT($0.count), $0.baseAddress, &cchActual))
         $1 = Int(cchActual)
       }
       return String(decoding: buffer, as: UTF16.self)
@@ -72,9 +59,7 @@ public class IWICComponentInfo: IUnknown {
   public func GetSigningStatus() throws -> DWORD {
     return try perform(as: WinSDK.IWICComponentInfo.self) { pThis in
       var Status: DWORD = DWORD(0)
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetSigningStatus(pThis, &Status)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetSigningStatus(pThis, &Status))
       return Status
     }
   }
@@ -82,16 +67,11 @@ public class IWICComponentInfo: IUnknown {
   public func GetSpecVersion() throws -> String {
     return try perform(as: WinSDK.IWICComponentInfo.self) { pThis in
       var cchActual: UINT = UINT(0)
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetSpecVersion(pThis, 0, nil, &cchActual)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetSpecVersion(pThis, 0, nil, &cchActual))
 
       let buffer: [WCHAR] =
           try Array<WCHAR>(unsafeUninitializedCapacity: Int(cchActual)) {
-        let hr: HRESULT =
-            pThis.pointee.lpVtbl.pointee.GetSpecVersion(pThis, UINT($0.count),
-                                                        $0.baseAddress, &cchActual)
-        guard hr == S_OK else { throw COMError(hr: hr) }
+        try CHECKED(pThis.pointee.lpVtbl.pointee.GetSpecVersion(pThis, UINT($0.count), $0.baseAddress, &cchActual))
         $1 = Int(cchActual)
       }
       return String(decoding: buffer, as: UTF16.self)
@@ -101,9 +81,7 @@ public class IWICComponentInfo: IUnknown {
   public func GetVendorGUID() throws -> GUID {
     return try perform(as: WinSDK.IWICComponentInfo.self) { pThis in
       var guidVendor: GUID = GUID()
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetVendorGUID(pThis, &guidVendor)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetVendorGUID(pThis, &guidVendor))
       return guidVendor
     }
   }
@@ -111,16 +89,11 @@ public class IWICComponentInfo: IUnknown {
   public func GetVersion() throws -> String {
     return try perform(as: WinSDK.IWICComponentInfo.self) { pThis in
       var cchActual: UINT = UINT(0)
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetVersion(pThis, 0, nil, &cchActual)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetVersion(pThis, 0, nil, &cchActual))
 
       let buffer: [WCHAR] =
           try Array<WCHAR>(unsafeUninitializedCapacity: Int(cchActual)) {
-        let hr: HRESULT =
-            pThis.pointee.lpVtbl.pointee.GetVersion(pThis, UINT($0.count),
-                                                    $0.baseAddress, &cchActual)
-        guard hr == S_OK else { throw COMError(hr: hr) }
+        try CHECKED(pThis.pointee.lpVtbl.pointee.GetVersion(pThis, UINT($0.count), $0.baseAddress, &cchActual))
         $1 = Int(cchActual)
       }
       return String(decoding: buffer, as: UTF16.self)

--- a/Sources/SwiftCOM/Interfaces/Human/IWICFastMetadataEncoder.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICFastMetadataEncoder.swift
@@ -12,18 +12,14 @@ public class IWICFastMetadataEncoder: IUnknown {
 
   public func Commit() throws {
     return try perform(as: WinSDK.IWICFastMetadataEncoder.self) { pThis in
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.Commit(pThis)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Commit(pThis))
     }
   }
 
   public func GetMetadataQueryWriter() throws -> IWICMetadataQueryWriter {
     return try perform(as: WinSDK.IWICFastMetadataEncoder.self) { pThis in
       var pIMetadataQueryWriter: UnsafeMutablePointer<WinSDK.IWICMetadataQueryWriter>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetMetadataQueryWriter(pThis,
-                                                              &pIMetadataQueryWriter)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetMetadataQueryWriter(pThis, &pIMetadataQueryWriter))
       return IWICMetadataQueryWriter(pUnk: pIMetadataQueryWriter)
     }
   }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICFormatConverter.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICFormatConverter.swift
@@ -15,11 +15,7 @@ public class IWICFormatConverter: IWICBitmapSource {
       throws -> Bool {
     return try perform(as: WinSDK.IWICFormatConverter.self) { pThis in
       var fCanConvert: WindowsBool = false
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.CanConvert(pThis, srcPixelFormat,
-                                                  dstPixelFormat,
-                                                  &fCanConvert)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.CanConvert(pThis, srcPixelFormat, dstPixelFormat, &fCanConvert))
       return fCanConvert == true
     }
   }
@@ -31,13 +27,7 @@ public class IWICFormatConverter: IWICBitmapSource {
                          _ alphaThresholdPercent: Double,
                          _ paletteTranslate: WICBitmapPaletteType) throws {
     return try perform(as: WinSDK.IWICFormatConverter.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.Initialize(pThis, RawPointer(pISource),
-                                                  dstFormat, dither,
-                                                  RawPointer(pIPalette),
-                                                  alphaThresholdPercent,
-                                                  paletteTranslate)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Initialize(pThis, RawPointer(pISource), dstFormat, dither, RawPointer(pIPalette), alphaThresholdPercent, paletteTranslate))
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICImagingFactory.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICImagingFactory.swift
@@ -16,10 +16,7 @@ public class IWICImagingFactory: IUnknown {
       throws -> IWICBitmap {
     return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
       var pIBitmap: UnsafeMutablePointer<WinSDK.IWICBitmap>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.CreateBitmap(pThis, uiWidth, uiHeight,
-                                                    pixelFormat, option, &pIBitmap)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.CreateBitmap(pThis, uiWidth, uiHeight, pixelFormat, option, &pIBitmap))
       return IWICBitmap(pUnk: pIBitmap)
     }
   }
@@ -27,9 +24,7 @@ public class IWICImagingFactory: IUnknown {
   public func CreateBitmapClipper() throws -> IWICBitmapClipper {
     return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
       var pIBitmapClipper: UnsafeMutablePointer<WinSDK.IWICBitmapClipper>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.CreateBitmapClipper(pThis, &pIBitmapClipper)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.CreateBitmapClipper(pThis, &pIBitmapClipper))
       return IWICBitmapClipper(pUnk: pIBitmapClipper)
     }
   }
@@ -37,10 +32,7 @@ public class IWICImagingFactory: IUnknown {
   public func CreateBitmapFlipRotator() throws -> IWICBitmapFlipRotator {
     return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
       var pIBitmapFlipRotator: UnsafeMutablePointer<WinSDK.IWICBitmapFlipRotator>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.CreateBitmapFlipRotator(pThis,
-                                                               &pIBitmapFlipRotator)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.CreateBitmapFlipRotator(pThis, &pIBitmapFlipRotator))
       return IWICBitmapFlipRotator(pUnk: pIBitmapFlipRotator)
     }
   }
@@ -50,11 +42,7 @@ public class IWICImagingFactory: IUnknown {
       throws -> IWICBitmap {
     return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
       var pIBitmap: UnsafeMutablePointer<WinSDK.IWICBitmap>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.CreateBitmapFromHBITMAP(pThis, hBitmap,
-                                                              hPalette, option,
-                                                              &pIBitmap)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.CreateBitmapFromHBITMAP(pThis, hBitmap, hPalette, option, &pIBitmap))
       return IWICBitmap(pUnk: pIBitmap)
     }
   }
@@ -62,9 +50,7 @@ public class IWICImagingFactory: IUnknown {
   public func CreateBitmapFromHICON(_ hIcon: HICON) throws -> IWICBitmap {
     return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
       var pIBitmap: UnsafeMutablePointer<WinSDK.IWICBitmap>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.CreateBitmapFromHICON(pThis, hIcon, &pIBitmap)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.CreateBitmapFromHICON(pThis, hIcon, &pIBitmap))
       return IWICBitmap(pUnk: pIBitmap)
     }
   }
@@ -75,14 +61,11 @@ public class IWICImagingFactory: IUnknown {
       throws -> IWICBitmap {
     return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
       var pIBitmap: UnsafeMutablePointer<WinSDK.IWICBitmap>?
-      let hr: HRESULT = pbBuffer.withUnsafeMutableBufferPointer {
-        pThis.pointee.lpVtbl.pointee.CreateBitmapFromMemory(pThis, uiWidth, uiHeight,
-                                                            pixelFormat, cbStride,
-                                                            UINT($0.count),
-                                                            $0.baseAddress,
-                                                            &pIBitmap)
+      try CHECKED {
+        pbBuffer.withUnsafeMutableBufferPointer {
+          pThis.pointee.lpVtbl.pointee.CreateBitmapFromMemory(pThis, uiWidth, uiHeight, pixelFormat, cbStride, UINT($0.count), $0.baseAddress, &pIBitmap)
+        }
       }
-      guard hr == S_OK else { throw COMError(hr: hr) }
       return IWICBitmap(pUnk: pIBitmap)
     }
   }
@@ -92,11 +75,7 @@ public class IWICImagingFactory: IUnknown {
       throws -> IWICBitmap {
     return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
       var pIBitmap: UnsafeMutablePointer<WinSDK.IWICBitmap>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.CreateBitmapFromSource(pThis,
-                                                              RawPointer(pIBitmapSource),
-                                                              option, &pIBitmap)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.CreateBitmapFromSource(pThis, RawPointer(pIBitmapSource), option, &pIBitmap))
       return IWICBitmap(pUnk: pIBitmap)
     }
   }
@@ -106,13 +85,7 @@ public class IWICImagingFactory: IUnknown {
                                          _ height: UINT) throws -> IWICBitmap {
     return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
       var pIBitmap: UnsafeMutablePointer<WinSDK.IWICBitmap>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.CreateBitmapFromSourceRect(pThis,
-                                                                  RawPointer(pIBitmapSource),
-                                                                  x, y, width,
-                                                                  height,
-                                                                  &pIBitmap)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.CreateBitmapFromSourceRect(pThis, RawPointer(pIBitmapSource), x, y, width, height, &pIBitmap))
       return IWICBitmap(pUnk: pIBitmap)
     }
   }
@@ -120,9 +93,7 @@ public class IWICImagingFactory: IUnknown {
   public func CreateBitmapScaler() throws -> IWICBitmapScaler {
     return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
       var pIBitmapScaler: UnsafeMutablePointer<WinSDK.IWICBitmapScaler>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.CreateBitmapScaler(pThis, &pIBitmapScaler)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.CreateBitmapScaler(pThis, &pIBitmapScaler))
       return IWICBitmapScaler(pUnk: pIBitmapScaler)
     }
   }
@@ -130,10 +101,7 @@ public class IWICImagingFactory: IUnknown {
   public func CreateColorContext() throws -> IWICColorContext {
     return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
       var pIWICColorContext: UnsafeMutablePointer<WinSDK.IWICColorContext>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.CreateColorContext(pThis,
-                                                          &pIWICColorContext)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.CreateColorContext(pThis, &pIWICColorContext))
       return IWICColorContext(pUnk: pIWICColorContext)
     }
   }
@@ -141,10 +109,7 @@ public class IWICImagingFactory: IUnknown {
   public func CreateColorTransformer() throws -> IWICColorTransform {
     return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
       var pIWICColorTransform: UnsafeMutablePointer<WinSDK.IWICColorTransform>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.CreateColorTransformer(pThis,
-                                                              &pIWICColorTransform)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.CreateColorTransformer(pThis, &pIWICColorTransform))
       return IWICColorTransform(pUnk: pIWICColorTransform)
     }
   }
@@ -154,12 +119,7 @@ public class IWICImagingFactory: IUnknown {
       throws -> IEnumUnknown {
     return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
       var pIEnumUnknown: UnsafeMutablePointer<WinSDK.IEnumUnknown>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.CreateComponentEnumerator(pThis,
-                                                                 componentTypes,
-                                                                 options,
-                                                                 &pIEnumUnknown)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.CreateComponentEnumerator(pThis, componentTypes, options, &pIEnumUnknown))
       return IEnumUnknown(pUnk: pIEnumUnknown)
     }
   }
@@ -168,10 +128,7 @@ public class IWICImagingFactory: IUnknown {
       throws -> IWICComponentInfo {
     return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
       var pIInfo: UnsafeMutablePointer<WinSDK.IWICComponentInfo>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.CreateComponentInfo(pThis, clsidComponent,
-                                                           &pIInfo)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.CreateComponentInfo(pThis, clsidComponent, &pIInfo))
       return IWICComponentInfo(pUnk: pIInfo)
     }
   }
@@ -181,15 +138,13 @@ public class IWICImagingFactory: IUnknown {
       throws -> IWICBitmapDecoder {
     return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
       var pIDecoder: UnsafeMutablePointer<WinSDK.IWICBitmapDecoder>?
-      let hr: HRESULT
+
       if var guidVendor = guidVendor {
-        hr = pThis.pointee.lpVtbl.pointee.CreateDecoder(pThis, guidContainerFormat,
-                                                        &guidVendor, &pIDecoder)
+        try CHECKED(pThis.pointee.lpVtbl.pointee.CreateDecoder(pThis, guidContainerFormat, &guidVendor, &pIDecoder))
       } else {
-        hr = pThis.pointee.lpVtbl.pointee.CreateDecoder(pThis, guidContainerFormat,
-                                                        nil, &pIDecoder)
+        try CHECKED(pThis.pointee.lpVtbl.pointee.CreateDecoder(pThis, guidContainerFormat, nil, &pIDecoder))
       }
-      guard hr == S_OK else { throw COMError(hr: hr) }
+
       return IWICBitmapDecoder(pUnk: pIDecoder)
     }
   }
@@ -200,17 +155,11 @@ public class IWICImagingFactory: IUnknown {
       throws -> IWICBitmapDecoder {
     return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
       var pIDecoder: UnsafeMutablePointer<WinSDK.IWICBitmapDecoder>?
-      let hr: HRESULT
       if var guidVendor = guidVendor {
-        hr = pThis.pointee.lpVtbl.pointee
-                .CreateDecoderFromFileHandle(pThis, hFile, &guidVendor,
-                                             metadataOptions, &pIDecoder)
+        try CHECKED(pThis.pointee.lpVtbl.pointee.CreateDecoderFromFileHandle(pThis, hFile, &guidVendor, metadataOptions, &pIDecoder))
       } else {
-        hr = pThis.pointee.lpVtbl.pointee
-                .CreateDecoderFromFileHandle(pThis, hFile, nil, metadataOptions,
-                                             &pIDecoder)
+        try CHECKED(pThis.pointee.lpVtbl.pointee.CreateDecoderFromFileHandle(pThis, hFile, nil, metadataOptions, &pIDecoder))
       }
-      guard hr == S_OK else { throw COMError(hr: hr) }
       return IWICBitmapDecoder(pUnk: pIDecoder)
     }
   }
@@ -222,24 +171,19 @@ public class IWICImagingFactory: IUnknown {
       throws -> IWICBitmapDecoder {
     return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
       var pIDecoder: UnsafeMutablePointer<WinSDK.IWICBitmapDecoder>?
-      let hr: HRESULT
       if var guidVendor = guidVendor {
-        hr = szFileName.withCString(encodedAs: UTF16.self) {
-          pThis.pointee.lpVtbl.pointee.CreateDecoderFromFilename(pThis, $0,
-                                                                 &guidVendor,
-                                                                 dwDesiredAccess,
-                                                                 metadataOptions,
-                                                                 &pIDecoder)
+        try CHECKED {
+          szFileName.withCString(encodedAs: UTF16.self) {
+            pThis.pointee.lpVtbl.pointee.CreateDecoderFromFilename(pThis, $0, &guidVendor, dwDesiredAccess, metadataOptions, &pIDecoder)
+          }
         }
       } else {
-        hr = szFileName.withCString(encodedAs: UTF16.self) {
-          pThis.pointee.lpVtbl.pointee.CreateDecoderFromFilename(pThis, $0, nil,
-                                                                 dwDesiredAccess,
-                                                                 metadataOptions,
-                                                                 &pIDecoder)
+        try CHECKED {
+          szFileName.withCString(encodedAs: UTF16.self) {
+            pThis.pointee.lpVtbl.pointee.CreateDecoderFromFilename(pThis, $0, nil, dwDesiredAccess, metadataOptions, &pIDecoder)
+          }
         }
       }
-      guard hr == S_OK else { throw COMError(hr: hr) }
       return IWICBitmapDecoder(pUnk: pIDecoder)
     }
   }
@@ -249,17 +193,11 @@ public class IWICImagingFactory: IUnknown {
       throws -> IWICBitmapDecoder {
     return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
       var pIDecoder: UnsafeMutablePointer<WinSDK.IWICBitmapDecoder>?
-      let hr: HRESULT
       if var guidVendor = guidVendor {
-        hr = pThis.pointee.lpVtbl.pointee
-                .CreateDecoderFromStream(pThis, RawPointer(pIStream), &guidVendor,
-                                         metadataOptions, &pIDecoder)
+        try CHECKED(pThis.pointee.lpVtbl.pointee.CreateDecoderFromStream(pThis, RawPointer(pIStream), &guidVendor, metadataOptions, &pIDecoder))
       } else {
-        hr = pThis.pointee.lpVtbl.pointee
-                .CreateDecoderFromStream(pThis, RawPointer(pIStream), nil,
-                                         metadataOptions, &pIDecoder)
+        try CHECKED(pThis.pointee.lpVtbl.pointee.CreateDecoderFromStream(pThis, RawPointer(pIStream), nil, metadataOptions, &pIDecoder))
       }
-      guard hr == S_OK else { throw COMError(hr: hr) }
       return IWICBitmapDecoder(pUnk: pIDecoder)
     }
   }
@@ -268,15 +206,11 @@ public class IWICImagingFactory: IUnknown {
                             _ guidVendor: GUID?) throws -> IWICBitmapEncoder {
     return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
       var pIEncoder: UnsafeMutablePointer<WinSDK.IWICBitmapEncoder>?
-      let hr: HRESULT
       if var guidVendor = guidVendor {
-        hr = pThis.pointee.lpVtbl.pointee.CreateEncoder(pThis, guidContainerFormat,
-                                                        &guidVendor, &pIEncoder)
+        try CHECKED(pThis.pointee.lpVtbl.pointee.CreateEncoder(pThis, guidContainerFormat, &guidVendor, &pIEncoder))
       } else {
-        hr = pThis.pointee.lpVtbl.pointee.CreateEncoder(pThis, guidContainerFormat,
-                                                        nil, &pIEncoder)
+        try CHECKED(pThis.pointee.lpVtbl.pointee.CreateEncoder(pThis, guidContainerFormat, nil, &pIEncoder))
       }
-      guard hr == S_OK else { throw COMError(hr: hr) }
       return IWICBitmapEncoder(pUnk: pIEncoder)
     }
   }
@@ -285,11 +219,7 @@ public class IWICImagingFactory: IUnknown {
       throws -> IWICFastMetadataEncoder {
     return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
       var pIFastEncoder: UnsafeMutablePointer<WinSDK.IWICFastMetadataEncoder>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee
-              .CreateFastMetadataEncoderFromDecoder(pThis, RawPointer(pIDecoder),
-                                                    &pIFastEncoder)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.CreateFastMetadataEncoderFromDecoder(pThis, RawPointer(pIDecoder), &pIFastEncoder))
       return IWICFastMetadataEncoder(pUnk: pIFastEncoder)
     }
   }
@@ -298,12 +228,7 @@ public class IWICImagingFactory: IUnknown {
       throws -> IWICFastMetadataEncoder {
     return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
       var pIFastEncoder: UnsafeMutablePointer<WinSDK.IWICFastMetadataEncoder>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee
-              .CreateFastMetadataEncoderFromFrameDecode(pThis,
-                                                        RawPointer(pIFrameDecoder),
-                                                        &pIFastEncoder)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.CreateFastMetadataEncoderFromFrameDecode(pThis, RawPointer(pIFrameDecoder), &pIFastEncoder))
       return IWICFastMetadataEncoder(pUnk: pIFastEncoder)
     }
   }
@@ -311,10 +236,7 @@ public class IWICImagingFactory: IUnknown {
   public func CreateFormatConverter() throws -> IWICFormatConverter {
     return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
       var pIFormatConverter: UnsafeMutablePointer<WinSDK.IWICFormatConverter>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.CreateFormatConverter(pThis,
-                                                             &pIFormatConverter)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.CreateFormatConverter(pThis, &pIFormatConverter))
       return IWICFormatConverter(pUnk: pIFormatConverter)
     }
   }
@@ -322,9 +244,7 @@ public class IWICImagingFactory: IUnknown {
   public func CreatePalette() throws -> IWICPalette {
     return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
       var pIPalette: UnsafeMutablePointer<WinSDK.IWICPalette>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.CreatePalette(pThis, &pIPalette)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.CreatePalette(pThis, &pIPalette))
       return IWICPalette(pUnk: pIPalette)
     }
   }
@@ -334,16 +254,11 @@ public class IWICImagingFactory: IUnknown {
       throws -> IWICMetadataQueryWriter {
     return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
       var pIQueryWriter: UnsafeMutablePointer<WinSDK.IWICMetadataQueryWriter>?
-      let hr: HRESULT
       if var guidVendor = guidVendor {
-        hr = pThis.pointee.lpVtbl.pointee
-                .CreateQueryWriter(pThis, guidMetadataFormat, &guidVendor,
-                                  &pIQueryWriter)
+        try CHECKED(pThis.pointee.lpVtbl.pointee.CreateQueryWriter(pThis, guidMetadataFormat, &guidVendor, &pIQueryWriter))
       } else {
-        hr = pThis.pointee.lpVtbl.pointee
-                .CreateQueryWriter(pThis, guidMetadataFormat, nil, &pIQueryWriter)
+        try CHECKED(pThis.pointee.lpVtbl.pointee.CreateQueryWriter(pThis, guidMetadataFormat, nil, &pIQueryWriter))
       }
-      guard hr == S_OK else { throw COMError(hr: hr) }
       return IWICMetadataQueryWriter(pUnk: pIQueryWriter)
     }
   }
@@ -353,17 +268,11 @@ public class IWICImagingFactory: IUnknown {
       throws -> IWICMetadataQueryWriter {
     return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
       var pIQueryWriter: UnsafeMutablePointer<WinSDK.IWICMetadataQueryWriter>?
-      let hr: HRESULT
       if var guidVendor = guidVendor {
-        hr = pThis.pointee.lpVtbl.pointee
-                .CreateQueryWriterFromReader(pThis, RawPointer(pIQueryReader),
-                                             &guidVendor, &pIQueryWriter)
+        try CHECKED(pThis.pointee.lpVtbl.pointee.CreateQueryWriterFromReader(pThis, RawPointer(pIQueryReader), &guidVendor, &pIQueryWriter))
       } else {
-        hr = pThis.pointee.lpVtbl.pointee
-                .CreateQueryWriterFromReader(pThis, RawPointer(pIQueryReader),
-                                             nil, &pIQueryWriter)
+        try CHECKED(pThis.pointee.lpVtbl.pointee.CreateQueryWriterFromReader(pThis, RawPointer(pIQueryReader), nil, &pIQueryWriter))
       }
-      guard hr == S_OK else { throw COMError(hr: hr) }
       return IWICMetadataQueryWriter(pUnk: pIQueryWriter)
     }
   }
@@ -371,9 +280,7 @@ public class IWICImagingFactory: IUnknown {
   public func CreateStream() throws -> IWICStream {
     return try perform(as: WinSDK.IWICImagingFactory.self) { pThis in
       var pIWICStream: UnsafeMutablePointer<WinSDK.IWICStream>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.CreateStream(pThis, &pIWICStream)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.CreateStream(pThis, &pIWICStream))
       return IWICStream(pUnk: pIWICStream)
     }
   }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICMetadataQueryReader.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICMetadataQueryReader.swift
@@ -13,10 +13,7 @@ public class IWICMetadataQueryReader: IUnknown {
   public func GetContainerFormat() throws -> GUID {
     return try perform(as: WinSDK.IWICMetadataQueryReader.self) { pThis in
       var guidContainerFormat: GUID = GUID()
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetContainerFormat(pThis,
-                                                          &guidContainerFormat)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetContainerFormat(pThis, &guidContainerFormat))
       return guidContainerFormat
     }
   }
@@ -24,9 +21,7 @@ public class IWICMetadataQueryReader: IUnknown {
   public func GetEnumerator() throws -> IEnumString {
     return try perform(as: WinSDK.IWICMetadataQueryReader.self) { pThis in
       var pIEnumString: UnsafeMutablePointer<WinSDK.IEnumString>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetEnumerator(pThis, &pIEnumString)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetEnumerator(pThis, &pIEnumString))
       return IEnumString(pUnk: pIEnumString)
     }
   }
@@ -34,18 +29,11 @@ public class IWICMetadataQueryReader: IUnknown {
   public func GetLocation() throws -> String {
     return try perform(as: WinSDK.IWICMetadataQueryReader.self) { pThis in
       var cchActualLength: UINT = UINT(0)
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetLocation(pThis, 0, nil,
-                                                   &cchActualLength)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetLocation(pThis, 0, nil, &cchActualLength))
 
       let buffer: [WCHAR] =
           try Array<WCHAR>(unsafeUninitializedCapacity: Int(cchActualLength)) {
-        let hr: HRESULT =
-            pThis.pointee.lpVtbl.pointee.GetLocation(pThis, UINT($0.count),
-                                                    $0.baseAddress,
-                                                    &cchActualLength)
-        guard hr == S_OK else { throw COMError(hr: hr) }
+        try CHECKED(pThis.pointee.lpVtbl.pointee.GetLocation(pThis, UINT($0.count), $0.baseAddress, &cchActualLength))
         $1 = Int(cchActualLength)
       }
       return String(decoding: buffer, as: UTF16.self)
@@ -55,10 +43,11 @@ public class IWICMetadataQueryReader: IUnknown {
   public func GetMetadataByName(_ szName: String) throws -> PROPVARIANT {
     return try perform(as: WinSDK.IWICMetadataQueryReader.self) { pThis in
       var varValue: PROPVARIANT = PROPVARIANT()
-      let hr: HRESULT = szName.withCString(encodedAs: UTF16.self) {
-        pThis.pointee.lpVtbl.pointee.GetMetadataByName(pThis, $0, &varValue)
+      try CHECKED {
+        szName.withCString(encodedAs: UTF16.self) {
+          pThis.pointee.lpVtbl.pointee.GetMetadataByName(pThis, $0, &varValue)
+        }
       }
-      guard hr == S_OK else { throw COMError(hr: hr) }
       return varValue
     }
   }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICMetadataQueryWriter.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICMetadataQueryWriter.swift
@@ -12,20 +12,22 @@ public class IWICMetadataQueryWriter: IWICMetadataQueryReader {
 
   public func RemoveMetadataByName(_ szName: String) throws {
     return try perform(as: WinSDK.IWICMetadataQueryWriter.self) { pThis in
-      let hr: HRESULT = szName.withCString(encodedAs: UTF16.self) {
-        pThis.pointee.lpVtbl.pointee.RemoveMetadataByName(pThis, $0)
+      try CHECKED {
+        szName.withCString(encodedAs: UTF16.self) {
+          pThis.pointee.lpVtbl.pointee.RemoveMetadataByName(pThis, $0)
+        }
       }
-      guard hr == S_OK else { throw COMError(hr: hr) }
     }
   }
 
   public func SetMetadataByName(_ szName: String, _ varValue: PROPVARIANT) throws {
     return try perform(as: WinSDK.IWICMetadataQueryWriter.self) { pThis in
       var varValue = varValue
-      let hr: HRESULT = szName.withCString(encodedAs: UTF16.self) {
-        pThis.pointee.lpVtbl.pointee.SetMetadataByName(pThis, $0, &varValue)
+      try CHECKED {
+        szName.withCString(encodedAs: UTF16.self) {
+          pThis.pointee.lpVtbl.pointee.SetMetadataByName(pThis, $0, &varValue)
+        }
       }
-      guard hr == S_OK else { throw COMError(hr: hr) }
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICPalette.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICPalette.swift
@@ -13,8 +13,7 @@ public class IWICPalette: IUnknown {
   public func GetColorCount() throws -> UINT {
     return try perform(as: WinSDK.IWICPalette.self) { pThis in
       var cCount: UINT = UINT(0)
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetColorCount(pThis, &cCount)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetColorCount(pThis, &cCount))
       return cCount
     }
   }
@@ -24,10 +23,7 @@ public class IWICPalette: IUnknown {
       let cCount: UINT = try GetColorCount()
       return try Array<WICColor>(unsafeUninitializedCapacity: Int(cCount)) {
         var cActualColors: UINT = UINT(0)
-        let hr: HRESULT =
-            pThis.pointee.lpVtbl.pointee.GetColors(pThis, cCount, $0.baseAddress,
-                                                  &cActualColors)
-        guard hr == S_OK else { throw COMError(hr: hr) }
+        try CHECKED(pThis.pointee.lpVtbl.pointee.GetColors(pThis, cCount, $0.baseAddress, &cActualColors))
         $1 = Int(cActualColors)
       }
     }
@@ -36,9 +32,7 @@ public class IWICPalette: IUnknown {
   public func GetType() throws -> WICBitmapPaletteType {
     return try perform(as: WinSDK.IWICPalette.self) { pThis in
       var ePaletteType: WICBitmapPaletteType = WICBitmapPaletteType(0)
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetType(pThis, &ePaletteType)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetType(pThis, &ePaletteType))
       return ePaletteType
     }
   }
@@ -46,9 +40,7 @@ public class IWICPalette: IUnknown {
   public func HasAlpha() throws -> Bool {
     return try perform(as: WinSDK.IWICPalette.self) { pThis in
       var fHasAlpha: WindowsBool = false
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.HasAlpha(pThis, &fHasAlpha)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.HasAlpha(pThis, &fHasAlpha))
       return fHasAlpha == true
     }
   }
@@ -56,11 +48,11 @@ public class IWICPalette: IUnknown {
   public func InitializeCustom(_ pColors: [WICColor]) throws {
     return try perform(as: WinSDK.IWICPalette.self) { pThis in
       var pColors: [WICColor] = pColors
-      let hr: HRESULT = pColors.withUnsafeMutableBufferPointer {
-        pThis.pointee.lpVtbl.pointee.InitializeCustom(pThis, $0.baseAddress,
-                                                      UINT($0.count))
+      try CHECKED {
+        pColors.withUnsafeMutableBufferPointer {
+          pThis.pointee.lpVtbl.pointee.InitializeCustom(pThis, $0.baseAddress, UINT($0.count))
+        }
       }
-      guard hr == S_OK else { throw COMError(hr: hr) }
     }
   }
 
@@ -68,40 +60,27 @@ public class IWICPalette: IUnknown {
                                    _ cCount: UINT,
                                    _ fAddTransparentColor: WindowsBool) throws {
     return try perform(as: WinSDK.IWICPalette.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.InitializeFromBitmap(pThis,
-                                                            RawPointer(pISurface),
-                                                            cCount,
-                                                            fAddTransparentColor)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.InitializeFromBitmap(pThis, RawPointer(pISurface), cCount, fAddTransparentColor))
     }
   }
 
   public func InitializeFromPalette(_ pIPalette: IWICPalette) throws {
     return try perform(as: WinSDK.IWICPalette.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.InitializeFromPalette(pThis,
-                                                            RawPointer(pIPalette))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.InitializeFromPalette(pThis, RawPointer(pIPalette)))
     }
   }
 
   public func InitializePredefined(_ ePaletteType: WICBitmapPaletteType,
                                    _ fAddTransparentColor: WindowsBool) throws {
     return try perform(as: WinSDK.IWICPalette.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.InitializePredefined(pThis, ePaletteType,
-                                                            fAddTransparentColor)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.InitializePredefined(pThis, ePaletteType, fAddTransparentColor))
     }
   }
 
   public func IsBlackWhite() throws -> Bool {
     return try perform(as: WinSDK.IWICPalette.self) { pThis in
       var fIsBlackWhite: WindowsBool = false
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.IsBlackWhite(pThis, &fIsBlackWhite)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.IsBlackWhite(pThis, &fIsBlackWhite))
       return fIsBlackWhite == true
     }
   }
@@ -109,9 +88,7 @@ public class IWICPalette: IUnknown {
   public func IsGrayscale() throws -> Bool {
     return try perform(as: WinSDK.IWICPalette.self) { pThis in
       var fIsGrayscale: WindowsBool = false
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.IsGrayscale(pThis, &fIsGrayscale)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.IsGrayscale(pThis, &fIsGrayscale))
       return fIsGrayscale == true
     }
   }

--- a/Sources/SwiftCOM/Interfaces/Human/IWICStream.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICStream.swift
@@ -13,20 +13,17 @@ public class IWICStream: IStream {
   public func InitializeFromFilename(_ szFileName: String,
                                      _ dwDesiredAccess: DWORD) throws {
     return try perform(as: WinSDK.IWICStream.self) { pThis in
-      let hr: HRESULT = szFileName.withCString(encodedAs: UTF16.self) {
-        pThis.pointee.lpVtbl.pointee.InitializeFromFilename(pThis, $0,
-                                                            dwDesiredAccess)
+      try CHECKED {
+        szFileName.withCString(encodedAs: UTF16.self) {
+          pThis.pointee.lpVtbl.pointee.InitializeFromFilename(pThis, $0, dwDesiredAccess)
+        }
       }
-      guard hr == S_OK else { throw COMError(hr: hr) }
     }
   }
 
   public func InitializeFromIStream(_ pIStream: IStream) throws {
     return try perform(as: WinSDK.IWICStream.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.InitializeFromIStream(pThis,
-                                                            RawPointer(pIStream))
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.InitializeFromIStream(pThis, RawPointer(pIStream)))
     }
   }
 
@@ -34,22 +31,14 @@ public class IWICStream: IStream {
                                           _ ulOffset: ULARGE_INTEGER,
                                           _ ulMaxSize: ULARGE_INTEGER) throws {
     return try perform(as: WinSDK.IWICStream.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.InitializeFromIStreamRegion(pThis,
-                                                                  RawPointer(pIStream),
-                                                                  ulOffset,
-                                                                  ulMaxSize)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.InitializeFromIStreamRegion(pThis, RawPointer(pIStream), ulOffset, ulMaxSize))
     }
   }
 
   public func InitializeFromMemory(_ pbBuffer: UnsafeMutablePointer<BYTE>?,
                                    _ cbBufferSize: DWORD) throws {
     return try perform(as: WinSDK.IWICStream.self) { pThis in
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.InitializeFromMemory(pThis, pbBuffer,
-                                                            cbBufferSize)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.InitializeFromMemory(pThis, pbBuffer, cbBufferSize))
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/ITypeComp.swift
+++ b/Sources/SwiftCOM/Interfaces/ITypeComp.swift
@@ -22,10 +22,7 @@ open class ITypeComp: IUnknown {
       var pTInfo: UnsafeMutablePointer<WinSDK.ITypeInfo>?
       var DescKind: DESCKIND = DESCKIND_MAX
       var BindPtr: BINDPTR = BINDPTR()
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.Bind(pThis, &szName, lHashVal, wFlags,
-                                            &pTInfo, &DescKind, &BindPtr)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Bind(pThis, &szName, lHashVal, wFlags, &pTInfo, &DescKind, &BindPtr))
       return (ITypeInfo(pUnk: pTInfo), DescKind, BindPtr)
     }
   }
@@ -37,10 +34,7 @@ open class ITypeComp: IUnknown {
       var szName: [OLECHAR] = Array<OLECHAR>(from: name)
       var pTInfo: UnsafeMutablePointer<WinSDK.ITypeInfo>?
       var pTComp: UnsafeMutablePointer<WinSDK.ITypeComp>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.BindType(pThis, &szName, lHashVal,
-                                                &pTInfo, &pTComp)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.BindType(pThis, &szName, lHashVal, &pTInfo, &pTComp))
       return (ITypeInfo(pUnk: pTInfo), ITypeComp(pUnk: pTComp))
     }
   }

--- a/Sources/SwiftCOM/Interfaces/ITypeInfo.swift
+++ b/Sources/SwiftCOM/Interfaces/ITypeInfo.swift
@@ -13,12 +13,11 @@ open class ITypeInfo: IUnknown {
   // TODO(compnerd) create a managed copy of TYPEATTR
   /// Retrieves a `TYPEATTR` structure that contains the attributes of the type
   /// description.
-  public func GetTypeAttr() throws -> UnsafeMutablePointer<TYPEATTR> {
+  public func GetTypeAttr() throws -> UnsafeMutablePointer<TYPEATTR>? {
     return try perform(as: WinSDK.ITypeInfo.self) { pThis in
       var pTypeAttr: UnsafeMutablePointer<TYPEATTR>?
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetTypeAttr(pThis, &pTypeAttr)
-      guard hr == S_OK else { throw COMError(hr: hr) }
-      return pTypeAttr!
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetTypeAttr(pThis, &pTypeAttr))
+      return pTypeAttr
     }
   }
 
@@ -27,8 +26,7 @@ open class ITypeInfo: IUnknown {
   public func GetTypeComp() throws -> ITypeComp {
     return try perform(as: WinSDK.ITypeInfo.self) { pThis in
       var pTComp: UnsafeMutablePointer<WinSDK.ITypeComp>?
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee.GetTypeComp(pThis, &pTComp)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetTypeComp(pThis, &pTComp))
       return ITypeComp(pUnk: pTComp)
     }
   }
@@ -36,25 +34,21 @@ open class ITypeInfo: IUnknown {
   // TODO(compnerd) create a managed copy of FUNCDESC
   /// Retrieves the `FUNCDESC` structure that contains information about a
   /// specified function.
-  public func GetFuncDesc(_ index: UINT) throws -> UnsafeMutablePointer<FUNCDESC> {
+  public func GetFuncDesc(_ index: UINT) throws -> UnsafeMutablePointer<FUNCDESC>?{
     return try perform(as: WinSDK.ITypeInfo.self) { pThis in
       var pFuncDesc: UnsafeMutablePointer<FUNCDESC>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetFuncDesc(pThis, index, &pFuncDesc)
-      guard hr == S_OK else { throw COMError(hr: hr) }
-      return pFuncDesc!
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetFuncDesc(pThis, index, &pFuncDesc))
+      return pFuncDesc
     }
   }
 
   // TODO(compnerd) create a managed copy of VARDESC
   /// Retrieves a `VARDESC` structure that describes the specified variable.
-  public func GetVarDesc(_ index: UINT) throws -> UnsafeMutablePointer<VARDESC> {
+  public func GetVarDesc(_ index: UINT) throws -> UnsafeMutablePointer<VARDESC>? {
     return try perform(as: WinSDK.ITypeInfo.self) { pThis in
       var pVarDesc: UnsafeMutablePointer<VARDESC>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetVarDesc(pThis, index, &pVarDesc)
-      guard hr == S_OK else { throw COMError(hr: hr) }
-      return pVarDesc!
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetVarDesc(pThis, index, &pVarDesc))
+      return pVarDesc
     }
   }
 
@@ -69,10 +63,7 @@ open class ITypeInfo: IUnknown {
       defer { rgBstrNames.deallocate() }
 
       var cNames: UINT = 0
-      let hr: HRESULT =
-        pThis.pointee.lpVtbl.pointee.GetNames(pThis, member, rgBstrNames,
-                                              cMaxNames + 1, &cNames)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetNames(pThis, member, rgBstrNames, cMaxNames + 1, &cNames))
 
       var names: [String] = Array<String>()
       names.reserveCapacity(Int(cNames))
@@ -90,9 +81,7 @@ open class ITypeInfo: IUnknown {
   public func GetRefTypeOfImplType(_ index: UINT) throws -> HREFTYPE {
     return try perform(as: WinSDK.ITypeInfo.self) { pThis in
       var pRefType: HREFTYPE = HREFTYPE()
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetRefTypeOfImplType(pThis, index, &pRefType)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetRefTypeOfImplType(pThis, index, &pRefType))
       return pRefType
     }
   }
@@ -102,10 +91,7 @@ open class ITypeInfo: IUnknown {
   public func GetImplTypeFlags(_ index: UINT) throws -> INT {
     return try perform(as: WinSDK.ITypeInfo.self) { pThis in
       var ImplTypeFlags: INT = INT()
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetImplTypeFlags(pThis, index,
-                                                        &ImplTypeFlags)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetImplTypeFlags(pThis, index, &ImplTypeFlags))
       return ImplTypeFlags
     }
   }
@@ -121,10 +107,7 @@ open class ITypeInfo: IUnknown {
 
       var MemId: [MEMBERID] =
           Array<MEMBERID>(repeating: MEMBERID_NIL, count: names.count)
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetIDsOfNames(pThis, &rgszNames,
-                                                    UINT(names.count), &MemId)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetIDsOfNames(pThis, &rgszNames, UINT(names.count), &MemId))
       return MemId
     }
   }
@@ -136,11 +119,7 @@ open class ITypeInfo: IUnknown {
       var VarResult: VARIANT = VARIANT()
       var ExcepInfo: EXCEPINFO = EXCEPINFO()
       var uArgError: UINT = 0
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.Invoke(pThis, pInstance, member, wFlags,
-                                              &pDispParams, &VarResult,
-                                              &ExcepInfo, &uArgError)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Invoke(pThis, pInstance, member, wFlags, &pDispParams, &VarResult, &ExcepInfo, &uArgError))
       return (result: VarResult, exception: ExcepInfo, error: uArgError)
     }
   }
@@ -156,10 +135,7 @@ open class ITypeInfo: IUnknown {
       var dwHelpContext: DWORD = DWORD.max
       var bstrHelpFile: BSTR?
 
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee
-          .GetDocumentation(pThis, member, &bstrName, &bstrDocString,
-                            &dwHelpContext, &bstrHelpFile)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetDocumentation(pThis, member, &bstrName, &bstrDocString, &dwHelpContext, &bstrHelpFile))
       defer {
         SysFreeString(bstrName)
         SysFreeString(bstrDocString)
@@ -181,11 +157,7 @@ open class ITypeInfo: IUnknown {
       var BstrName: BSTR?
       var wOrdianal: WORD = 0
 
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetDllEntry(pThis, member, invocation,
-                                                  &BstrDllName, &BstrName,
-                                                  &wOrdianal)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetDllEntry(pThis, member, invocation, &BstrDllName, &BstrName, &wOrdianal))
       defer {
         SysFreeString(BstrDllName)
         SysFreeString(BstrName)
@@ -200,9 +172,7 @@ open class ITypeInfo: IUnknown {
   public func GetRefTypeInfo(_ hRefType: HREFTYPE) throws -> ITypeInfo {
     return try perform(as: WinSDK.ITypeInfo.self) { pThis in
       var pTInfo: UnsafeMutablePointer<WinSDK.ITypeInfo>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetRefTypeInfo(pThis, hRefType, &pTInfo)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetRefTypeInfo(pThis, hRefType, &pTInfo))
       return ITypeInfo(pUnk: pTInfo)
     }
   }
@@ -210,28 +180,22 @@ open class ITypeInfo: IUnknown {
   /// Retrieves the addresses of static functions or variables, such as those
   /// defined in a DLL.
   public func AddressOfMember(_ member: MEMBERID, _ invocation: INVOKEKIND)
-      throws -> UnsafeMutableRawPointer {
+      throws -> UnsafeMutableRawPointer? {
     return try perform(as: WinSDK.ITypeInfo.self) { pThis in
       var pMember: UnsafeMutableRawPointer?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.AddressOfMember(pThis, member, invocation,
-                                                      &pMember)
-      guard hr == S_OK else { throw COMError(hr: hr) }
-      return pMember!
+      try CHECKED(pThis.pointee.lpVtbl.pointee.AddressOfMember(pThis, member, invocation, &pMember))
+      return pMember
     }
   }
 
   /// Creates a new instance of a type that describes a component object class
   /// (coclass).
   public func CreateInstance(_ pUnkOuter: IUnknown, _ riid: REFIID)
-      throws -> UnsafeMutableRawPointer {
+      throws -> UnsafeMutableRawPointer? {
     return try perform(as: WinSDK.ITypeInfo.self) { pThis in
       var pvObj: PVOID?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.CreateInstance(pThis, pUnkOuter.pUnk,
-                                                      riid, &pvObj)
-      guard hr == S_OK else { throw COMError(hr: hr) }
-      return pvObj!
+      try CHECKED(pThis.pointee.lpVtbl.pointee.CreateInstance(pThis, RawPointer(pUnkOuter), riid, &pvObj))
+      return pvObj
     }
   }
 
@@ -239,9 +203,7 @@ open class ITypeInfo: IUnknown {
   public func GetMops(_ member: MEMBERID) throws -> String {
     return try perform(as: WinSDK.ITypeInfo.self) { pThis in
       var BstrMops: BSTR?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetMops(pThis, member, &BstrMops)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetMops(pThis, member, &BstrMops))
       defer { SysFreeString(BstrMops) }
 
       return BstrMops == nil ? "" : String(from: BstrMops!)
@@ -254,9 +216,7 @@ open class ITypeInfo: IUnknown {
     return try perform(as: WinSDK.ITypeInfo.self) { pThis in
       var pTLib: UnsafeMutablePointer<WinSDK.ITypeLib>?
       var Index: UINT = 0
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetContainingTypeLib(pThis, &pTLib, &Index)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetContainingTypeLib(pThis, &pTLib, &Index))
       return (typelib: ITypeLib(pUnk: pTLib), index: Index)
     }
   }

--- a/Sources/SwiftCOM/Interfaces/ITypeLib.swift
+++ b/Sources/SwiftCOM/Interfaces/ITypeLib.swift
@@ -21,9 +21,7 @@ open class ITypeLib: IUnknown {
   public func GetTypeInfo(_ index: UINT) throws -> ITypeInfo {
     return try perform(as: WinSDK.ITypeLib.self) { pThis in
       var info: UnsafeMutablePointer<WinSDK.ITypeInfo>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetTypeInfo(pThis, index, &info)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetTypeInfo(pThis, index, &info))
       return ITypeInfo(pUnk: info)
     }
   }
@@ -32,9 +30,7 @@ open class ITypeLib: IUnknown {
   public func GetTypeInfoType(_ index: UINT) throws -> TYPEKIND {
     return try perform(as: WinSDK.ITypeLib.self) { pThis in
       var kind: TYPEKIND = TKIND_MAX
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetTypeInfoType(pThis, index, &kind)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetTypeInfoType(pThis, index, &kind))
       return kind
     }
   }
@@ -44,9 +40,7 @@ open class ITypeLib: IUnknown {
     return try perform(as: WinSDK.ITypeLib.self) { pThis in
       var guid: GUID = guid
       var pTinfo: UnsafeMutablePointer<WinSDK.ITypeInfo>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetTypeInfoOfGuid(pThis, &guid, &pTinfo)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetTypeInfoOfGuid(pThis, &guid, &pTinfo))
       return ITypeInfo(pUnk: pTinfo)
     }
   }
@@ -55,9 +49,7 @@ open class ITypeLib: IUnknown {
   public func GetLibAttr() throws -> UnsafeMutablePointer<TLIBATTR> {
     return try perform(as: WinSDK.ITypeLib.self) { pThis in
       var pTLibAttr: UnsafeMutablePointer<TLIBATTR>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetLibAttr(pThis, &pTLibAttr)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetLibAttr(pThis, &pTLibAttr))
       return pTLibAttr!
     }
   }
@@ -67,9 +59,7 @@ open class ITypeLib: IUnknown {
   public func GetTypeComp() throws -> ITypeComp {
     return try perform(as: WinSDK.ITypeLib.self) { pThis in
       var pTComp: UnsafeMutablePointer<WinSDK.ITypeComp>?
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.GetTypeComp(pThis, &pTComp)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetTypeComp(pThis, &pTComp))
       return ITypeComp(pUnk: pTComp)
     }
   }
@@ -85,11 +75,7 @@ open class ITypeLib: IUnknown {
       var bstrDocString: BSTR!
       var dwHelpContext: DWORD = DWORD.max
       var bstrHelpFile: BSTR!
-
-      let hr: HRESULT = pThis.pointee.lpVtbl.pointee
-          .GetDocumentation(pThis, index, &bstrName, &bstrDocString,
-                            &dwHelpContext, &bstrHelpFile)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetDocumentation(pThis, index, &bstrName, &bstrDocString, &dwHelpContext, &bstrHelpFile))
       defer {
         SysFreeString(bstrName)
         SysFreeString(bstrDocString)
@@ -107,9 +93,7 @@ open class ITypeLib: IUnknown {
     return try perform(as: WinSDK.ITypeLib.self) { pThis in
       var szNameBuf: [OLECHAR] = Array<OLECHAR>(from: name)
       var fName: WindowsBool = false
-      let hr: HRESULT =
-          pThis.pointee.lpVtbl.pointee.IsName(pThis, &szNameBuf, hash, &fName)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.IsName(pThis, &szNameBuf, hash, &fName))
       return fName == true
     }
   }
@@ -123,19 +107,14 @@ open class ITypeLib: IUnknown {
       var pTInfo: [UnsafeMutablePointer<WinSDK.ITypeInfo>?] = []
       var rgMemId: [MEMBERID] = []
       var cFound: USHORT = 0
-      var hr: HRESULT = S_OK
 
-      hr = pThis.pointee.lpVtbl.pointee.FindName(pThis, &szNameBuf, lHashVal,
-                                                &pTInfo, &rgMemId, &cFound)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.FindName(pThis, &szNameBuf, lHashVal, &pTInfo, &rgMemId, &cFound))
 
       pTInfo = Array<UnsafeMutablePointer<WinSDK.ITypeInfo>?>(repeating: nil,
                                                               count: Int(cFound))
       rgMemId = Array<MEMBERID>(repeating: MEMBERID_NIL, count: Int(cFound))
 
-      hr = pThis.pointee.lpVtbl.pointee.FindName(pThis, &szNameBuf, lHashVal,
-                                                &pTInfo, &rgMemId, &cFound)
-      guard hr == S_OK else { throw COMError(hr: hr) }
+      try CHECKED(pThis.pointee.lpVtbl.pointee.FindName(pThis, &szNameBuf, lHashVal, &pTInfo, &rgMemId, &cFound))
 
       return (0 ..< cFound).map {
         (ITypeInfo(pUnk: pTInfo[Int($0)]), rgMemId[Int($0)])

--- a/Sources/SwiftCOM/Interfaces/IUnknown.swift
+++ b/Sources/SwiftCOM/Interfaces/IUnknown.swift
@@ -32,9 +32,7 @@ open class IUnknown {
     var iid: IID = iid
 
     var pointer: UnsafeMutableRawPointer?
-    let hr: HRESULT =
-        pUnk.pointee.lpVtbl.pointee.QueryInterface(pUnk, &iid, &pointer)
-    guard hr == S_OK else { throw COMError(hr: hr) }
+    try CHECKED(pUnk.pointee.lpVtbl.pointee.QueryInterface(pUnk, &iid, &pointer))
     return IUnknown(pUnk: pointer)
   }
 
@@ -62,10 +60,7 @@ extension IUnknown {
     var iid: IID = T.IID
 
     var pointer: UnsafeMutableRawPointer?
-    let hr: HRESULT =
-        CoCreateInstance(&clsid, pUnkOuter?.pUnk, DWORD(dwClsContext.rawValue),
-                         &iid, &pointer)
-    guard hr == S_OK else { throw COMError(hr: hr) }
+    try CHECKED(CoCreateInstance(&clsid, pUnkOuter?.pUnk, DWORD(dwClsContext.rawValue), &iid, &pointer))
     return T(pUnk: pointer)
   }
 }

--- a/Sources/SwiftCOM/Shell.swift
+++ b/Sources/SwiftCOM/Shell.swift
@@ -10,9 +10,7 @@ import WinSDK
 public func SHCreateItemFromParsingName(_ pszPath: String, _ pbc: IBindCtx?,
                                         _ riid: inout IID) throws -> IUnknown {
   var pv: UnsafeMutableRawPointer?
-  let hr: HRESULT =
-      SHCreateItemFromParsingName(pszPath.wide, RawPointer(pbc), &riid, &pv)
-  guard hr == S_OK else { throw COMError(hr: hr) }
+  try CHECKED(SHCreateItemFromParsingName(pszPath.wide, RawPointer(pbc), &riid, &pv))
   return IUnknown(pUnk: pv)
 }
 
@@ -21,8 +19,6 @@ public func SHCreateItemFromParsingName<T: IUnknown>(_ pszPath: String,
     throws -> T {
   var riid: IID = T.IID
   var pv: UnsafeMutableRawPointer?
-  let hr: HRESULT =
-      SHCreateItemFromParsingName(pszPath.wide, RawPointer(pbc), &riid, &pv)
-  guard hr == S_OK else { throw COMError(hr: hr) }
+  try CHECKED(SHCreateItemFromParsingName(pszPath.wide, RawPointer(pbc), &riid, &pv))
   return T(pUnk: pv)
 }

--- a/Sources/SwiftCOM/Support/Error.swift
+++ b/Sources/SwiftCOM/Support/Error.swift
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
+ * All Rights Reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ **/
+
+import WinSDK
+
+@discardableResult
+func CHECKED(_ body: () -> HRESULT) throws -> HRESULT {
+  let hr: HRESULT = body()
+  guard hr >= 0 else { throw COMError(hr: hr) }
+  return hr
+}
+
+@discardableResult
+func CHECKED(_ body: @autoclosure () -> HRESULT) throws -> HRESULT {
+  let hr: HRESULT = body()
+  guard hr >= 0 else { throw COMError(hr: hr) }
+  return hr
+}
+
+func SUCCEEDED(_ body: @autoclosure () -> HRESULT) -> Bool {
+  let hr: HRESULT = body()
+  return hr >= 0
+}


### PR DESCRIPTION
This adds a pair of `CHECKED` overloads which check that the result is
a success code.  If the code is a failure, the failure is convered to a
`COMError`.  The formatting changes are non-material, and temporary.