### PR TITLE
DirectX: further completeness

### DIFF
--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12CommandQueue.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12CommandQueue.swift
@@ -16,23 +16,73 @@ public class ID3D12CommandQueue: ID3D12Pageable {
     }
   }
 
-  public func  CopyTileMappings(_ pDstResource: ID3D12Resource,
-                                _ pDstRegionStartCoordinate: D3D12_TILED_RESOURCE_COORDINATE,
-                                _ pSrcResource: ID3D12Resource,
-                                _ pSrcRegionStartCoordinate: D3D12_TILED_RESOURCE_COORDINATE,
-                                _ pRegionSize: D3D12_TILE_REGION_SIZE,
+  public func  CopyTileMappings(_ pDstResource: ID3D12Resource?,
+                                _ pDstRegionStartCoordinate: UnsafePointer<D3D12_TILED_RESOURCE_COORDINATE>?,
+                                _ pSrcResource: ID3D12Resource?,
+                                _ pSrcRegionStartCoordinate: UnsafePointer<D3D12_TILED_RESOURCE_COORDINATE>?,
+                                _ pRegionSize: UnsafePointer<D3D12_TILE_REGION_SIZE>?,
                                 _ Flags: D3D12_TILE_MAPPING_FLAGS) throws {
     return try perform(as: WinSDK.ID3D12CommandQueue.self) { pThis in
-      var pDstRegionStartCoordinate = pDstRegionStartCoordinate
-      var pSrcRegionStartCoordinate = pSrcRegionStartCoordinate
-      var pRegionSize = pRegionSize
-      pThis.pointee.lpVtbl.pointee.CopyTileMappings(pThis, RawPointer(pDstResource), &pDstRegionStartCoordinate, RawPointer(pSrcResource), &pSrcRegionStartCoordinate, &pRegionSize, Flags)
+      pThis.pointee.lpVtbl.pointee.CopyTileMappings(pThis, RawPointer(pDstResource), pDstRegionStartCoordinate, RawPointer(pSrcResource), pSrcRegionStartCoordinate, pRegionSize, Flags)
     }
   }
 
   public func EndEvent() throws {
     return try perform(as: WinSDK.ID3D12CommandQueue.self) { pThis in
       pThis.pointee.lpVtbl.pointee.EndEvent(pThis)
+    }
+  }
+
+  public func ExecuteCommandLists(_ NumCommandLists: UINT, _ ppCommandLists: UnsafePointer<UnsafeMutablePointer<WinSDK.ID3D12CommandList>?>?) throws {
+    return try perform(as: WinSDK.ID3D12CommandQueue.self) { pThis in
+      pThis.pointee.lpVtbl.pointee.ExecuteCommandLists(pThis, NumCommandLists, ppCommandLists)
+    }
+  }
+
+  public func GetClockCalibration() throws -> (UINT64, UINT64) {
+    return try perform(as: WinSDK.ID3D12CommandQueue.self) { pThis in
+      var GPUTimeStamp: UINT64 = UINT64()
+      var CPUTimeStamp: UINT64 = UINT64()
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetClockCalibration(pThis, &GPUTimeStamp, &CPUTimeStamp))
+      return (GPUTimeStamp, CPUTimeStamp)
+    }
+  }
+
+  public func GetDesc() throws -> D3D12_COMMAND_QUEUE_DESC {
+    return try perform(as: WinSDK.ID3D12CommandQueue.self) { pThis in
+      return pThis.pointee.lpVtbl.pointee.GetDesc(pThis)
+    }
+  }
+
+  public func GetTimestampFrequency() throws -> UINT64 {
+    return try perform(as: WinSDK.ID3D12CommandQueue.self) { pThis in
+      var Frequency: UINT64 = UINT64()
+      try CHECKED(pThis.pointee.lpVtbl.pointee.GetTimestampFrequency(pThis, &Frequency))
+      return Frequency
+    }
+  }
+
+  public func SetMarker(_ Metadata: UINT, _ pData: UnsafeRawPointer?, _ Size: UINT) throws {
+    return try perform(as: WinSDK.ID3D12CommandQueue.self) { pThis in
+      pThis.pointee.lpVtbl.pointee.SetMarker(pThis, Metadata, pData, Size)
+    }
+  }
+
+  public func Signal(_ pFence: ID3D12Fence, _ Value: UINT64) throws {
+    return try perform(as: WinSDK.ID3D12CommandQueue.self) { pThis in
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Signal(pThis, RawPointer(pFence), Value))
+    }
+  }
+
+  public func UpdateTileMappings(_ pResource: ID3D12Resource?, _ NumResourceRegions: UINT, _ pResourceRegionStartCoordinates: UnsafePointer<D3D12_TILED_RESOURCE_COORDINATE>?, _ pResourceRegionSizes: UnsafePointer<D3D12_TILE_REGION_SIZE>?, _ pHeap: ID3D12Heap?, _ NumRanges: UINT, _ pRangeFlags: UnsafePointer<D3D12_TILE_RANGE_FLAGS>?, _ pHeapRangeStartOffsets: UnsafePointer<UINT>?, _ pRangeTileCounts: UnsafePointer<UINT>?, _ Flags: D3D12_TILE_MAPPING_FLAGS) throws {
+    return try perform(as: WinSDK.ID3D12CommandQueue.self) { pThis in
+      pThis.pointee.lpVtbl.pointee.UpdateTileMappings(pThis, RawPointer(pResource), NumResourceRegions, pResourceRegionStartCoordinates, pResourceRegionSizes, RawPointer(pHeap), NumRanges, pRangeFlags, pHeapRangeStartOffsets, pRangeTileCounts, Flags)
+    }
+  }
+
+  public func Wait(_ pFence: ID3D12Fence?, _ Value: UINT64) throws {
+    return try perform(as: WinSDK.ID3D12CommandQueue.self) { pThis in
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Wait(pThis, RawPointer(pFence), Value))
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12GraphicsCommandList.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12GraphicsCommandList.swift
@@ -28,7 +28,7 @@ public class ID3D12GraphicsCommandList: ID3D12CommandList {
     }
   }
 
-  public func ClearRenderTargetView(_ RenderTargetView: D3D12_CPU_DESCRIPTOR_HANDLE, _ ColorRGBA: (FLOAT, FLOAT, FLOAT, FLOAT), _ NumRects: UINT, _ pRects: UnsafePointer<D3D12_RECT>) throws {
+  public func ClearRenderTargetView(_ RenderTargetView: D3D12_CPU_DESCRIPTOR_HANDLE, _ ColorRGBA: (FLOAT, FLOAT, FLOAT, FLOAT), _ NumRects: UINT, _ pRects: UnsafePointer<D3D12_RECT>?) throws {
     return try perform(as: WinSDK.ID3D12GraphicsCommandList.self) { pThis in
       var ColorRGBA = ColorRGBA
       withUnsafeBytes(of: &ColorRGBA) {
@@ -169,7 +169,7 @@ public class ID3D12GraphicsCommandList: ID3D12CommandList {
     }
   }
 
-  public func Reset(_ pAllocator: ID3D12CommandAllocator, _ pInitialState: ID3D12PipelineState) throws {
+  public func Reset(_ pAllocator: ID3D12CommandAllocator?, _ pInitialState: ID3D12PipelineState?) throws {
     return try perform(as: WinSDK.ID3D12GraphicsCommandList.self) { pThis in
       try CHECKED(pThis.pointee.lpVtbl.pointee.Reset(pThis, RawPointer(pAllocator), RawPointer(pInitialState)))
     }


### PR DESCRIPTION
Extend the interfaces for the `ID3D12GraphicsCommandList` to match the
official interface definition.  Tweak the nullability on some of the
parameters for `ID3D12CommandQueue`.