### PR TITLE
Interfaces: prepare for removal of `pUnk`

### DIFF
--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12Object.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12Object.swift
@@ -35,7 +35,7 @@ public class ID3D12Object: IUnknown {
   public func SetPrivateDataInterface(_ guid: REFGUID,
                                       _ pData: IUnknown?) throws {
     return try perform(as: WinSDK.ID3D12Object.self) { pThis in
-      try CHECKED(pThis.pointee.lpVtbl.pointee.SetPrivateDataInterface(pThis, guid, pData?.pUnk))
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetPrivateDataInterface(pThis, guid, RawPointer(pData)))
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IDXGIObject.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IDXGIObject.swift
@@ -32,7 +32,7 @@ public class IDXGIObject: IUnknown {
 
   public func SetPrivateDataInterface(_ Name: REFGUID, _ pData: IUnknown?) throws {
     return try perform(as: WinSDK.IDXGIObject.self) { pThis in
-      try CHECKED(pThis.pointee.lpVtbl.pointee.SetPrivateDataInterface(pThis, Name, pData?.pUnk))
+      try CHECKED(pThis.pointee.lpVtbl.pointee.SetPrivateDataInterface(pThis, Name, RawPointer(pData)))
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/IFileOperation.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IFileOperation.swift
@@ -55,7 +55,7 @@ public class IFileOperation: IUnknown {
 
   public func DeleteItems(_ punkItems: IUnknown) throws {
     return try perform(as: WinSDK.IFileOperation.self) { pThis in
-      try CHECKED(pThis.pointee.lpVtbl.pointee.DeleteItems(pThis, punkItems.pUnk))
+      try CHECKED(pThis.pointee.lpVtbl.pointee.DeleteItems(pThis, RawPointer(punkItems)))
     }
   }
 

--- a/Sources/SwiftCOM/Interfaces/Human/IRunningObjectTable.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IRunningObjectTable.swift
@@ -55,7 +55,7 @@ public class IRunningObjectTable: IUnknown {
                        _ pmkObjectName: IMoniker) throws -> DWORD {
     return try perform(as: WinSDK.IRunningObjectTable.self) { pThis in
       var dwRegister: DWORD = 0
-      try CHECKED(pThis.pointee.lpVtbl.pointee.Register(pThis, grfFlags, punkObject.pUnk, RawPointer(pmkObjectName), &dwRegister))
+      try CHECKED(pThis.pointee.lpVtbl.pointee.Register(pThis, grfFlags, RawPointer(punkObject), RawPointer(pmkObjectName), &dwRegister))
       return dwRegister
     }
   }

--- a/Sources/SwiftCOM/Support/RawTyped.swift
+++ b/Sources/SwiftCOM/Support/RawTyped.swift
@@ -7,7 +7,7 @@
 
 import WinSDK
 
-internal func RawPointer<T: IUnknown, U>(_ pUnk: T?)
+public func RawPointer<T: IUnknown, U>(_ pUnk: T?)
     -> UnsafeMutablePointer<U>? {
   guard let pUnk = pUnk else { return nil }
   if let pUnk: UnsafeMutableRawPointer = UnsafeMutableRawPointer(pUnk.pUnk) {


### PR DESCRIPTION
`IUnknown.pUnk` should not be accessible outside of `SwiftCOM`.
However, `RawPointer` can be useful for some APIs, so make that public
to have a blessed way to gain access to the underlying pointer type.