### PR TITLE
IUnknown: handle reference counting for COM

### DIFF
--- a/Sources/SwiftCOM/Support/RawTyped.swift
+++ b/Sources/SwiftCOM/Support/RawTyped.swift
@@ -10,7 +10,7 @@ import WinSDK
 public func RawPointer<T: IUnknown, U>(_ pUnk: T?)
     -> UnsafeMutablePointer<U>? {
   guard let pUnk = pUnk else { return nil }
-  if let pUnk: UnsafeMutableRawPointer = UnsafeMutableRawPointer(pUnk.pUnk) {
+  if let pUnk: UnsafeMutableRawPointer = UnsafeMutableRawPointer(pUnk.pUnk.borrow) {
     return pUnk.bindMemory(to: U.self, capacity: 1)
   }
   return nil


### PR DESCRIPTION
Convert the internal pointer to a reference to get reference counting
handled properly.  The member is shared across all copies, which COM
sees as a since instance.