### PR TITLE
D3D: add a convenience helper for `ID3D12Device::CreateGraphicsPipeli…

### DIFF
--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12Device.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12Device.swift
@@ -333,4 +333,11 @@ extension ID3D12Device {
       try CreateDepthStencilView(pResource, pDesc, DestDescriptor)
     }
   }
+
+
+  public func CreateGraphicsPipelineState<PSO: IUnknown>(_ Desc: D3D12_GRAPHICS_PIPELINE_STATE_DESC) throws -> PSO {
+    var Desc = Desc
+    var iid: IID = PSO.IID
+    return try PSO(pUnk: CreateGraphicsPipelineState(&Desc, &iid))
+  }
 }


### PR DESCRIPTION
…neState'

This allows an inline definition of the descriptor to create the
Pipeline State Object.