### PR TITLE
DirectX: add some more convenience overloads

### DIFF
--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12Device.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12Device.swift
@@ -340,4 +340,9 @@ extension ID3D12Device {
     var iid: IID = PSO.IID
     return try PSO(pUnk: CreateGraphicsPipelineState(&Desc, &iid))
   }
+
+  public func CreateConstantBufferView(_ Desc: D3D12_CONSTANT_BUFFER_VIEW_DESC, _ DestDescriptor: D3D12_CPU_DESCRIPTOR_HANDLE) throws {
+    var Desc = Desc
+    return try CreateConstantBufferView(&Desc, DestDescriptor)
+  }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12GraphicsCommandList.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12GraphicsCommandList.swift
@@ -319,3 +319,11 @@ public class ID3D12GraphicsCommandList: ID3D12CommandList {
     }
   }
 }
+
+extension ID3D12GraphicsCommandList {
+  public func SetDescriptorHeaps(_ heaps: [ID3D12DescriptorHeap]) throws {
+    var pHeaps: [UnsafeMutablePointer<WinSDK.ID3D12DescriptorHeap>?] =
+        heaps.map { RawPointer($0) }
+    return try SetDescriptorHeaps(UINT(pHeaps.count), &pHeaps)
+  }
+}


### PR DESCRIPTION
This adds a couple of extension interfaces which provide some syntactic
sugar for invocation with Swift constructs.  This makes the use of the
interfaces more convenient when writing an actual user of the
interfaces.