### PR TITLE
IDXGIOutput: correct `GetDisplayModeList`

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -40,6 +40,6 @@ jobs:
         Get-ChildItem Env: | % { echo "$($_.Name)=$($_.Value)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append }
 
     - name: Build
-      run: swift build -v
-    # - name: Run tests
-    #  run: swift test -v
+      run: swift build
+    - name: Run tests
+      run: swift test

--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,10 @@ let SwiftCOM = Package(
         .linkedLibrary("Ole32"),
         .linkedLibrary("PortableDeviceGuids"),
       ]
-    )
+    ),
+    .testTarget(
+      name: "SwiftCOMTests",
+      dependencies: ["SwiftCOM"]
+    ),
   ]
 )

--- a/Sources/SwiftCOM/Interfaces/Human/IDXGIOutput.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IDXGIOutput.swift
@@ -31,7 +31,6 @@ public class IDXGIOutput: IDXGIObject {
       var NumModes: UINT = 0
       try CHECKED(pThis.pointee.lpVtbl.pointee.GetDisplayModeList(pThis, EnumFormat, Flags, &NumModes, nil))
       return try Array<DXGI_MODE_DESC>(unsafeUninitializedCapacity: Int(NumModes)) {
-        var NumModes: UINT = 0
         try CHECKED(pThis.pointee.lpVtbl.pointee.GetDisplayModeList(pThis, EnumFormat, Flags, &NumModes, $0.baseAddress))
         $1 = Int(NumModes)
       }

--- a/Tests/SwiftCOMTests/IDXGIOutputTests.swift
+++ b/Tests/SwiftCOMTests/IDXGIOutputTests.swift
@@ -1,0 +1,34 @@
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+import SwiftCOM
+import XCTest
+
+import struct WinSDK.UINT
+import let WinSDK.DXGI_CREATE_FACTORY_DEBUG
+import let WinSDK.DXGI_FORMAT_R8G8B8A8_UNORM
+
+final class IDXGIOutputTests: XCTestCase {
+  func testGetDisplayModeList() {
+    let pFactory: IDXGIFactory2? =
+        try? CreateDXGIFactory2(UINT(DXGI_CREATE_FACTORY_DEBUG))
+    guard let pFactory = pFactory else {
+      return XCTFail("unable to create DXGIFactory" )
+    }
+
+    let pAdapter: IDXGIAdapter4? =
+        try? pFactory.EnumAdapters(UINT(0)).QueryInterface()
+    guard let pAdapter = pAdapter else {
+      return XCTFail("unable to get IDXGIAdapter4")
+    }
+
+    let pOutput: IDXGIOutput? = try? pAdapter.EnumOutputs(UINT(0))
+    guard let pOutput = pOutput else {
+      return XCTFail("unable to get IDXGIOutput")
+    }
+
+    let arrDisplayModes =
+        try! pOutput.GetDisplayModeList(DXGI_FORMAT_R8G8B8A8_UNORM, 0)
+    XCTAssertNotNil(arrDisplayModes)
+  }
+}


### PR DESCRIPTION
When `IDXGIOutput.GetDisplayModeList` is invoked with a buffer, the
`NumNodes` parameter is expected to be a non-zero value which indicates
the number of entries that can be held.  We would overwrite this value
with 0, which resulted in an error being reported:
~~~
0x887a0003 - The caller did not supply a sufficiently large buffer.
~~~
Avoid shadowing the variable to avoid this.  Introduce a test suite to
add coverage for this case.

Fixes: #59