### PR TITLE
SwiftCOM: update interfaces for newer SDK

### DIFF
--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12CommandQueue.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12CommandQueue.swift
@@ -50,7 +50,9 @@ public class ID3D12CommandQueue: ID3D12Pageable {
 
   public func GetDesc() throws -> D3D12_COMMAND_QUEUE_DESC {
     return try perform(as: WinSDK.ID3D12CommandQueue.self) { pThis in
-      return pThis.pointee.lpVtbl.pointee.GetDesc(pThis)
+      var desc: D3D12_COMMAND_QUEUE_DESC = D3D12_COMMAND_QUEUE_DESC()
+      let _ = pThis.pointee.lpVtbl.pointee.GetDesc(pThis, &desc)
+      return desc
     }
   }
 

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12DescriptorHeap.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12DescriptorHeap.swift
@@ -38,7 +38,9 @@ public class ID3D12DescriptorHeap: ID3D12Pageable {
 
   public func GetDesc() throws -> D3D12_DESCRIPTOR_HEAP_DESC {
     return try perform(as: WinSDK.ID3D12DescriptorHeap.self) { pThis in
-      return pThis.pointee.lpVtbl.pointee.GetDesc(pThis)
+      var desc: D3D12_DESCRIPTOR_HEAP_DESC = D3D12_DESCRIPTOR_HEAP_DESC()
+      let _ = pThis.pointee.lpVtbl.pointee.GetDesc(pThis, &desc)
+      return desc
     }
   }
 

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12Device.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12Device.swift
@@ -192,7 +192,9 @@ public class ID3D12Device: ID3D12Object {
 
   public func GetAdapterLuid() throws -> LUID {
     return try perform(as: WinSDK.ID3D12Device.self) { pThis in
-      return pThis.pointee.lpVtbl.pointee.GetAdapterLuid(pThis)
+      var luid: LUID = LUID()
+      let _ = pThis.pointee.lpVtbl.pointee.GetAdapterLuid(pThis, &luid)
+      return luid
     }
   }
 
@@ -209,7 +211,9 @@ public class ID3D12Device: ID3D12Object {
 
   public func GetCustomHeapProperties(_ nodeMask: UINT, _ heapType: D3D12_HEAP_TYPE) throws -> D3D12_HEAP_PROPERTIES {
     return try perform(as: WinSDK.ID3D12Device.self) { pThis in
-      return pThis.pointee.lpVtbl.pointee.GetCustomHeapProperties(pThis, nodeMask, heapType)
+      var properties: D3D12_HEAP_PROPERTIES = D3D12_HEAP_PROPERTIES()
+      let _ = pThis.pointee.lpVtbl.pointee.GetCustomHeapProperties(pThis, &properties, nodeMask, heapType)
+      return properties
     }
   }
 
@@ -233,7 +237,9 @@ public class ID3D12Device: ID3D12Object {
 
   public func GetResourceAllocationInfo(_ visibleMask: UINT, numResourceDescs: UINT, _ pResourceDescs: UnsafePointer<D3D12_RESOURCE_DESC>?) throws -> D3D12_RESOURCE_ALLOCATION_INFO {
     return try perform(as: WinSDK.ID3D12Device.self) { pThis in
-      return pThis.pointee.lpVtbl.pointee.GetResourceAllocationInfo(pThis, visibleMask, numResourceDescs, pResourceDescs)
+      var info: D3D12_RESOURCE_ALLOCATION_INFO = D3D12_RESOURCE_ALLOCATION_INFO()
+      let _ = pThis.pointee.lpVtbl.pointee.GetResourceAllocationInfo(pThis, &info, visibleMask, numResourceDescs, pResourceDescs)
+      return info
     }
   }
 

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12Heap.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12Heap.swift
@@ -12,7 +12,9 @@ public class ID3D12Heap: ID3D12Pageable {
 
   public func GetDesc() throws -> D3D12_HEAP_DESC {
     return try perform(as: WinSDK.ID3D12Heap.self) { pThis in
-      return pThis.pointee.lpVtbl.pointee.GetDesc(pThis)
+      var desc: D3D12_HEAP_DESC = D3D12_HEAP_DESC()
+      let _ = pThis.pointee.lpVtbl.pointee.GetDesc(pThis, &desc)
+      return desc
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12Resource.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12Resource.swift
@@ -12,7 +12,9 @@ public class ID3D12Resource: ID3D12Pageable {
 
   public func GetDesc() throws -> D3D12_RESOURCE_DESC {
     return try perform(as: WinSDK.ID3D12Resource.self) { pThis in
-      return pThis.pointee.lpVtbl.pointee.GetDesc(pThis)
+      var desc: D3D12_RESOURCE_DESC = D3D12_RESOURCE_DESC()
+      let _ = pThis.pointee.lpVtbl.pointee.GetDesc(pThis, &desc)
+      return desc
     }
   }
 


### PR DESCRIPTION
Many of the vtable issues have now been corrected.  Unfortunately, it is
unclear which SDK version fixed the issue and this makes providing a
backwards compatible implementation difficult.  I would be open to
patches to support the older SDKs while retaining the ability to use the
newer SDKs as well.  The newer SDKs are more critical for CI though as
the builders tend to have the newest SDKs installed.