### PR TITLE
SwiftCOM: adjust the copyright header style (NFC)

### DIFF
--- a/Sources/SwiftCOM/COMBase.swift
+++ b/Sources/SwiftCOM/COMBase.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/DirectX.swift
+++ b/Sources/SwiftCOM/DirectX.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Extensions/COMTypes+Extensions.swift
+++ b/Sources/SwiftCOM/Extensions/COMTypes+Extensions.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Extensions/DirectX+Extensions.swift
+++ b/Sources/SwiftCOM/Extensions/DirectX+Extensions.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Extensions/String+Extensions.swift
+++ b/Sources/SwiftCOM/Extensions/String+Extensions.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import ucrt
 import WinSDK

--- a/Sources/SwiftCOM/Extensions/WinSDK+Extensions.swift
+++ b/Sources/SwiftCOM/Extensions/WinSDK+Extensions.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Extensions/stdlib+Extensions.swift
+++ b/Sources/SwiftCOM/Extensions/stdlib+Extensions.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 internal func withUnsafeNullablePointer<T, Result>(to value: T?, _ body: (UnsafePointer<T>?) throws -> Result) rethrows -> Result {
   guard let value = value else { return try body(nil) }

--- a/Sources/SwiftCOM/Implementation/Human/IFileOperationProgressSink.swift
+++ b/Sources/SwiftCOM/Implementation/Human/IFileOperationProgressSink.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IBindCtx.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IBindCtx.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12CommandAllocator.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12CommandAllocator.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12CommandList.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12CommandList.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12CommandQueue.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12CommandQueue.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12CommandSignature.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12CommandSignature.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12Debug.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12Debug.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12DescriptorHeap.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12DescriptorHeap.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12Device.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12Device.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12Device1.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12Device1.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12Device2.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12Device2.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12DeviceChild.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12DeviceChild.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12Fence.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12Fence.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12Heap.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12Heap.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12InfoQueue.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12InfoQueue.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12Object.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12Object.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12Pageable.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12Pageable.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12PipelineState.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12PipelineState.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12QueryHeap.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12QueryHeap.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12Resource.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12Resource.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12RootSignature.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12RootSignature.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12StateObject.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12StateObject.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12VersionedRootSignatureDeserializer.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12VersionedRootSignatureDeserializer.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 import WinSDK.DirectX

--- a/Sources/SwiftCOM/Interfaces/Human/ID3DBlob.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3DBlob.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IDXGIAdapter.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IDXGIAdapter.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IDXGIAdapter1.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IDXGIAdapter1.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IDXGIAdapter2.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IDXGIAdapter2.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IDXGIAdapter3.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IDXGIAdapter3.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IDXGIAdapter4.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IDXGIAdapter4.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IDXGIDebug.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IDXGIDebug.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IDXGIDevice.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IDXGIDevice.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IDXGIDeviceSubObject.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IDXGIDeviceSubObject.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IDXGIFactory.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IDXGIFactory.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IDXGIFactory1.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IDXGIFactory1.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IDXGIFactory2.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IDXGIFactory2.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IDXGIFactory3.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IDXGIFactory3.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IDXGIFactory4.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IDXGIFactory4.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IDXGIFactory5.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IDXGIFactory5.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IDXGIFactory6.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IDXGIFactory6.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IDXGIObject.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IDXGIObject.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IDXGIOutput.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IDXGIOutput.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IDXGISurface.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IDXGISurface.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IDXGISwapChain.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IDXGISwapChain.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IDXGISwapChain1.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IDXGISwapChain1.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IDXGISwapChain2.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IDXGISwapChain2.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IDXGISwapChain3.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IDXGISwapChain3.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IDXGISwapChain4.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IDXGISwapChain4.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2021 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IEnumMoniker.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IEnumMoniker.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IEnumString.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IEnumString.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IEnumUnknown.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IEnumUnknown.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IErrorLog.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IErrorLog.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IFileOperation.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IFileOperation.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IMalloc.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IMalloc.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IMoniker.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IMoniker.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IObjectWithPropertyKey.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IObjectWithPropertyKey.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IOperationsProgressDialog.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IOperationsProgressDialog.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IPersist.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IPersist.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IPersistStream.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IPersistStream.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IPortableDeviceKeyCollection.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IPortableDeviceKeyCollection.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IPortableDevicePropVariantCollection.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IPortableDevicePropVariantCollection.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IPortableDeviceValues.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IPortableDeviceValues.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IPortableDeviceValuesCollection.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IPortableDeviceValuesCollection.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IPropertyBag2.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IPropertyBag2.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IPropertyChange.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IPropertyChange.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IPropertyChangeArray.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IPropertyChangeArray.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IPropertyStore.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IPropertyStore.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IRunningObjectTable.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IRunningObjectTable.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/ISensor.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ISensor.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/ISensorCollection.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ISensorCollection.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/ISensorDataReport.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ISensorDataReport.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/ISensorEvents.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ISensorEvents.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/ISensorManager.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ISensorManager.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/ISensorManagerEvents.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ISensorManagerEvents.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IShellItem.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IShellItem.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IStream.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IStream.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmap.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmap.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapClipper.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapClipper.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapCodecInfo.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapCodecInfo.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapDecoder.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapDecoder.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapDecoderInfo.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapDecoderInfo.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapEncoder.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapEncoder.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapEncoderInfo.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapEncoderInfo.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapFlipRotator.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapFlipRotator.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapFrameDecode.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapFrameDecode.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapFrameEncode.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapFrameEncode.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapLock.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapLock.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapScaler.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapScaler.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IWICBitmapSource.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICBitmapSource.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IWICColorContext.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICColorContext.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IWICColorTransform.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICColorTransform.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IWICComponentInfo.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICComponentInfo.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IWICFastMetadataEncoder.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICFastMetadataEncoder.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IWICFormatConverter.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICFormatConverter.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IWICImagingFactory.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICImagingFactory.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IWICMetadataQueryReader.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICMetadataQueryReader.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IWICMetadataQueryWriter.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICMetadataQueryWriter.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IWICPalette.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICPalette.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/Human/IWICStream.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/IWICStream.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/ITypeComp.swift
+++ b/Sources/SwiftCOM/Interfaces/ITypeComp.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/ITypeInfo.swift
+++ b/Sources/SwiftCOM/Interfaces/ITypeInfo.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/ITypeLib.swift
+++ b/Sources/SwiftCOM/Interfaces/ITypeLib.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Interfaces/IUnknown.swift
+++ b/Sources/SwiftCOM/Interfaces/IUnknown.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Shell.swift
+++ b/Sources/SwiftCOM/Shell.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Support/COMError.swift
+++ b/Sources/SwiftCOM/Support/COMError.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Support/Error.swift
+++ b/Sources/SwiftCOM/Support/Error.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 

--- a/Sources/SwiftCOM/Support/RawTyped.swift
+++ b/Sources/SwiftCOM/Support/RawTyped.swift
@@ -1,9 +1,5 @@
-/**
- * Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>
- * All Rights Reserved.
- *
- * SPDX-License-Identifier: BSD-3-Clause
- **/
+// Copyright 2020 Saleem Abdulrasool <compnerd@compnerd.org>. All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 
 import WinSDK
 


### PR DESCRIPTION
The Swift style requires that the copyright header uses the `//` as the
comment leader.  Failure to do so results in the copyright header being
treated as a documentation block.  This adjusts the copyright header to
follow the prescribed style.