### PR TITLE
Fixes for Windows 10 SDK?

### DIFF
--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12CommandQueue.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12CommandQueue.swift
@@ -46,9 +46,7 @@ public class ID3D12CommandQueue: ID3D12Pageable {
 
   public func GetDesc() throws -> D3D12_COMMAND_QUEUE_DESC {
     return try perform(as: WinSDK.ID3D12CommandQueue.self) { pThis in
-      var desc: D3D12_COMMAND_QUEUE_DESC = D3D12_COMMAND_QUEUE_DESC()
-      desc = pThis.pointee.lpVtbl.pointee.GetDesc(pThis)
-      return desc
+      pThis.pointee.lpVtbl.pointee.GetDesc(pThis)
     }
   }
 

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12CommandQueue.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12CommandQueue.swift
@@ -47,7 +47,7 @@ public class ID3D12CommandQueue: ID3D12Pageable {
   public func GetDesc() throws -> D3D12_COMMAND_QUEUE_DESC {
     return try perform(as: WinSDK.ID3D12CommandQueue.self) { pThis in
       var desc: D3D12_COMMAND_QUEUE_DESC = D3D12_COMMAND_QUEUE_DESC()
-      let _ = pThis.pointee.lpVtbl.pointee.GetDesc(pThis, &desc)
+      desc = pThis.pointee.lpVtbl.pointee.GetDesc(pThis)
       return desc
     }
   }

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12DescriptorHeap.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12DescriptorHeap.swift
@@ -34,9 +34,7 @@ public class ID3D12DescriptorHeap: ID3D12Pageable {
 
   public func GetDesc() throws -> D3D12_DESCRIPTOR_HEAP_DESC {
     return try perform(as: WinSDK.ID3D12DescriptorHeap.self) { pThis in
-      var desc: D3D12_DESCRIPTOR_HEAP_DESC = D3D12_DESCRIPTOR_HEAP_DESC()
-      desc = pThis.pointee.lpVtbl.pointee.GetDesc(pThis)
-      return desc
+      pThis.pointee.lpVtbl.pointee.GetDesc(pThis)
     }
   }
 

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12DescriptorHeap.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12DescriptorHeap.swift
@@ -35,7 +35,7 @@ public class ID3D12DescriptorHeap: ID3D12Pageable {
   public func GetDesc() throws -> D3D12_DESCRIPTOR_HEAP_DESC {
     return try perform(as: WinSDK.ID3D12DescriptorHeap.self) { pThis in
       var desc: D3D12_DESCRIPTOR_HEAP_DESC = D3D12_DESCRIPTOR_HEAP_DESC()
-      let _ = pThis.pointee.lpVtbl.pointee.GetDesc(pThis, &desc)
+      desc = pThis.pointee.lpVtbl.pointee.GetDesc(pThis)
       return desc
     }
   }

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12Device.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12Device.swift
@@ -189,7 +189,7 @@ public class ID3D12Device: ID3D12Object {
   public func GetAdapterLuid() throws -> LUID {
     return try perform(as: WinSDK.ID3D12Device.self) { pThis in
       var luid: LUID = LUID()
-      let _ = pThis.pointee.lpVtbl.pointee.GetAdapterLuid(pThis, &luid)
+      luid = pThis.pointee.lpVtbl.pointee.GetAdapterLuid(pThis)
       return luid
     }
   }
@@ -208,7 +208,7 @@ public class ID3D12Device: ID3D12Object {
   public func GetCustomHeapProperties(_ nodeMask: UINT, _ heapType: D3D12_HEAP_TYPE) throws -> D3D12_HEAP_PROPERTIES {
     return try perform(as: WinSDK.ID3D12Device.self) { pThis in
       var properties: D3D12_HEAP_PROPERTIES = D3D12_HEAP_PROPERTIES()
-      let _ = pThis.pointee.lpVtbl.pointee.GetCustomHeapProperties(pThis, &properties, nodeMask, heapType)
+      properties = pThis.pointee.lpVtbl.pointee.GetCustomHeapProperties(pThis, nodeMask, heapType)
       return properties
     }
   }
@@ -234,7 +234,7 @@ public class ID3D12Device: ID3D12Object {
   public func GetResourceAllocationInfo(_ visibleMask: UINT, numResourceDescs: UINT, _ pResourceDescs: UnsafePointer<D3D12_RESOURCE_DESC>?) throws -> D3D12_RESOURCE_ALLOCATION_INFO {
     return try perform(as: WinSDK.ID3D12Device.self) { pThis in
       var info: D3D12_RESOURCE_ALLOCATION_INFO = D3D12_RESOURCE_ALLOCATION_INFO()
-      let _ = pThis.pointee.lpVtbl.pointee.GetResourceAllocationInfo(pThis, &info, visibleMask, numResourceDescs, pResourceDescs)
+      info = pThis.pointee.lpVtbl.pointee.GetResourceAllocationInfo(pThis, visibleMask, numResourceDescs, pResourceDescs)
       return info
     }
   }

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12Device.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12Device.swift
@@ -188,9 +188,7 @@ public class ID3D12Device: ID3D12Object {
 
   public func GetAdapterLuid() throws -> LUID {
     return try perform(as: WinSDK.ID3D12Device.self) { pThis in
-      var luid: LUID = LUID()
-      luid = pThis.pointee.lpVtbl.pointee.GetAdapterLuid(pThis)
-      return luid
+      pThis.pointee.lpVtbl.pointee.GetAdapterLuid(pThis)
     }
   }
 
@@ -207,9 +205,7 @@ public class ID3D12Device: ID3D12Object {
 
   public func GetCustomHeapProperties(_ nodeMask: UINT, _ heapType: D3D12_HEAP_TYPE) throws -> D3D12_HEAP_PROPERTIES {
     return try perform(as: WinSDK.ID3D12Device.self) { pThis in
-      var properties: D3D12_HEAP_PROPERTIES = D3D12_HEAP_PROPERTIES()
-      properties = pThis.pointee.lpVtbl.pointee.GetCustomHeapProperties(pThis, nodeMask, heapType)
-      return properties
+      pThis.pointee.lpVtbl.pointee.GetCustomHeapProperties(pThis, nodeMask, heapType)
     }
   }
 
@@ -233,9 +229,7 @@ public class ID3D12Device: ID3D12Object {
 
   public func GetResourceAllocationInfo(_ visibleMask: UINT, numResourceDescs: UINT, _ pResourceDescs: UnsafePointer<D3D12_RESOURCE_DESC>?) throws -> D3D12_RESOURCE_ALLOCATION_INFO {
     return try perform(as: WinSDK.ID3D12Device.self) { pThis in
-      var info: D3D12_RESOURCE_ALLOCATION_INFO = D3D12_RESOURCE_ALLOCATION_INFO()
-      info = pThis.pointee.lpVtbl.pointee.GetResourceAllocationInfo(pThis, visibleMask, numResourceDescs, pResourceDescs)
-      return info
+      pThis.pointee.lpVtbl.pointee.GetResourceAllocationInfo(pThis, visibleMask, numResourceDescs, pResourceDescs)
     }
   }
 

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12Heap.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12Heap.swift
@@ -9,7 +9,7 @@ public class ID3D12Heap: ID3D12Pageable {
   public func GetDesc() throws -> D3D12_HEAP_DESC {
     return try perform(as: WinSDK.ID3D12Heap.self) { pThis in
       var desc: D3D12_HEAP_DESC = D3D12_HEAP_DESC()
-      let _ = pThis.pointee.lpVtbl.pointee.GetDesc(pThis, &desc)
+      desc = pThis.pointee.lpVtbl.pointee.GetDesc(pThis)
       return desc
     }
   }

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12Heap.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12Heap.swift
@@ -8,9 +8,7 @@ public class ID3D12Heap: ID3D12Pageable {
 
   public func GetDesc() throws -> D3D12_HEAP_DESC {
     return try perform(as: WinSDK.ID3D12Heap.self) { pThis in
-      var desc: D3D12_HEAP_DESC = D3D12_HEAP_DESC()
-      desc = pThis.pointee.lpVtbl.pointee.GetDesc(pThis)
-      return desc
+      pThis.pointee.lpVtbl.pointee.GetDesc(pThis)
     }
   }
 }

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12Resource.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12Resource.swift
@@ -9,7 +9,7 @@ public class ID3D12Resource: ID3D12Pageable {
   public func GetDesc() throws -> D3D12_RESOURCE_DESC {
     return try perform(as: WinSDK.ID3D12Resource.self) { pThis in
       var desc: D3D12_RESOURCE_DESC = D3D12_RESOURCE_DESC()
-      let _ = pThis.pointee.lpVtbl.pointee.GetDesc(pThis, &desc)
+      desc = pThis.pointee.lpVtbl.pointee.GetDesc(pThis)
       return desc
     }
   }

--- a/Sources/SwiftCOM/Interfaces/Human/ID3D12Resource.swift
+++ b/Sources/SwiftCOM/Interfaces/Human/ID3D12Resource.swift
@@ -8,9 +8,7 @@ public class ID3D12Resource: ID3D12Pageable {
 
   public func GetDesc() throws -> D3D12_RESOURCE_DESC {
     return try perform(as: WinSDK.ID3D12Resource.self) { pThis in
-      var desc: D3D12_RESOURCE_DESC = D3D12_RESOURCE_DESC()
-      desc = pThis.pointee.lpVtbl.pointee.GetDesc(pThis)
-      return desc
+      pThis.pointee.lpVtbl.pointee.GetDesc(pThis)
     }
   }
 


### PR DESCRIPTION
Not sure how ABI stability works in Windows, but I assume these fixes will be backwards compatible with older Windows SDKs?